### PR TITLE
CI: run some basic tests against antsibull-docs 1.0.0 and antsibull 0.44.0

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -52,6 +52,12 @@ jobs:
           poetry run antsibull-docs sphinx-init --lenient --dest-dir . --use-current --sphinx-theme sphinx_rtd_theme
         working-directory: antsibull-docs
 
+      - name: Patch build.sh to use poetry run
+        run: |
+          sed -i build.sh -e 's!antsibull-docs !poetry run antsibull-docs !g'
+          sed -i build.sh -e 's!sphinx-build !poetry run sphinx-build !g'
+        working-directory: antsibull-docs
+
       - name: Install dependencies
         run: |
           poetry run pip install ansible-core

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -1,0 +1,74 @@
+# Run some antsibull-docs 1.0.0 tests against the current development version of antsibull-core
+# to make sure we don't accidentally break compatibility.
+
+name: antsibull-docs compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run once per week (Monday at 04:00 UTC)
+  schedule:
+    - cron: '0 4 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out antsibull-core
+        uses: actions/checkout@v3
+        with:
+          path: antsibull-core
+
+      - name: Check out antsibull-docs 1.0.0
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-community/antsibull-docs
+          ref: 1.0.0
+          path: antsibull-docs
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+          poetry update
+        working-directory: antsibull-docs
+
+      # pyre should complain if a signature changed in an incompatible way
+      - name: Lint with pyre
+        run: |
+          ./lint-pyre.sh
+        working-directory: antsibull-docs
+
+      - name: Use antsibull-docs sphinx-init
+        run: |
+          poetry run antsibull-docs sphinx-init --lenient --dest-dir . --use-current --sphinx-theme sphinx_rtd_theme
+        working-directory: antsibull-docs
+
+      - name: Install dependencies
+        run: |
+          poetry run pip install ansible-core
+          poetry run pip install -r requirements.txt
+        working-directory: antsibull-docs
+
+      - name: Install collections
+        run: |
+          ansible-galaxy collection install community.docker sensu.sensu_go
+          git clone https://github.com/ansible-collections/community.crypto.git ~/.ansible/collections/ansible_collections/community/crypto
+
+      - name: Lint collection docs
+        run: |
+          poetry run antsibull-docs lint-collection-docs ~/.ansible/collections/ansible_collections/community/docker
+        working-directory: antsibull-docs
+
+      - name: Build docsite
+        run: |
+          ./build.sh
+        working-directory: antsibull-docs

--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           path: antsibull-core
 
-      # antsibull 0.44.0 depends on antsibull-docs as well, so install 1.0.0 of that
+      # antsibull 0.44.0 depends on antsibull-docs >= 1.0.0 as well, so install 1.0.0 of that
       - name: Check out antsibull-docs 1.0.0
         uses: actions/checkout@v3
         with:
@@ -29,20 +29,20 @@ jobs:
           ref: 1.0.0
           path: antsibull-docs
 
+      # antsibull 0.44.0 depends on antsibull-changelog >= 0.14.0 as well, so install 0.14.0 of that
+      - name: Check out antsibull-changelog 0.14.0
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-community/antsibull-changelog
+          ref: 0.14.0
+          path: antsibull-changelog
+
       - name: Check out antsibull 0.44.0
         uses: actions/checkout@v3
         with:
           repository: ansible-community/antsibull
           ref: 0.44.0
           path: antsibull
-
-      # antsibull 0.44.0 depends on antsibull-changelog 0.14.0
-      - name: Check out dependent project antsibull-changelog
-        uses: actions/checkout@v3
-        with:
-          repository: ansible-community/antsibull-changelog
-          ref: 0.14.0
-          path: antsibull-changelog
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v2

--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -1,0 +1,69 @@
+# Run some antsibull 0.44.0 tests against the current development version of antsibull-core
+# to make sure we don't accidentally break compatibility.
+
+name: antsibull compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run once per week (Monday at 04:00 UTC)
+  schedule:
+    - cron: '0 4 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out antsibull-core
+        uses: actions/checkout@v3
+        with:
+          path: antsibull-core
+
+      # antsibull 0.44.0 depends on antsibull-docs as well, so install 1.0.0 of that
+      - name: Check out antsibull-docs 1.0.0
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-community/antsibull-docs
+          ref: 1.0.0
+          path: antsibull-docs
+
+      - name: Check out antsibull 0.44.0
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-community/antsibull
+          ref: 0.44.0
+          path: antsibull
+
+      # antsibull 0.44.0 depends on antsibull-changelog 0.14.0
+      - name: Check out dependent project antsibull-changelog
+        uses: actions/checkout@v3
+        with:
+          repository: ansible-community/antsibull-changelog
+          ref: 0.14.0
+          path: antsibull-changelog
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+          poetry update
+        working-directory: antsibull
+
+      # pyre should complain if a signature changed in an incompatible way
+      - name: Lint with pyre
+        run: |
+          ./lint-pyre.sh
+        working-directory: antsibull
+
+      - name: "Test building a release: Ansible 6 with ansible-core devel"
+        run: |
+          ansible-playbook -vv playbooks/build-single-release.yaml -e 'antsibull_build_command="poetry run antsibull-build"' -e antsibull_ansible_version=6.99.0 -e antsibull_build_file=ansible-6.build -e antsibull_data_dir="{{ antsibull_data_git_dir }}/6" -e antsibull_ansible_git_version=devel
+        working-directory: antsibull


### PR DESCRIPTION
This should ensure that we don't accidentally break compatibility with older verisons of antsibull-docs that depend on antsibull-core 1.x.y. Obviously this isn't 100% covering everything, but it's a lot better than nothing :)