### PR TITLE
Fix async file copying helper; use aiofiles typeshed definitions instead of ignoring the package

### DIFF
--- a/changelogs/fragments/11-copy-fix.yml
+++ b/changelogs/fragments/11-copy-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix async file copying helper (https://github.com/ansible-community/antsibull-core/pull/11)."

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,8 +7,5 @@
 [mypy-sh.*]
 ignore_missing_imports = True
 
-[mypy-aiofiles.*]
-ignore_missing_imports = True
-
 [mypy-semantic_version.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pylint = "^2.12.0"
 pytest = "*"
 pytest-asyncio = ">= 0.12"
 pytest-cov = "*"
+types-aiofiles = "*"
 types-PyYAML = "*"
 
 [tool.isort]

--- a/src/antsibull_core/utils/io.py
+++ b/src/antsibull_core/utils/io.py
@@ -47,7 +47,7 @@ async def copy_file(source_path: str, dest_path: str) -> None:
                     # Since we already read the contents of the file to copy, simply write it to
                     # the destination instead of reading it again
                     async with aiofiles.open(dest_path, 'wb') as f_out:
-                        f_out.write(content_to_copy)
+                        await f_out.write(content_to_copy)
                     return
         except FileNotFoundError:
             # Destination (or source) file does not exist


### PR DESCRIPTION
See https://github.com/ansible-community/antsibull/pull/450