### PR TITLE
Fix overly restrictive file name types

### DIFF
--- a/changelogs/fragments/14-StrOrBytesPath.yaml
+++ b/changelogs/fragments/14-StrOrBytesPath.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Fix overly restrictive file name type annotations. Use ``StrOrBytesPath``
+    type annotation instead of ``str`` for functions that accept a file name.
+    (https://github.com/ansible-community/antsibull-core/pull/14)

--- a/changelogs/fragments/14-StrOrBytesPath.yaml
+++ b/changelogs/fragments/14-StrOrBytesPath.yaml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
   - Fix overly restrictive file name type annotations. Use ``StrOrBytesPath``
-    type annotation instead of ``str`` for functions that accept a file name.
-    (https://github.com/ansible-community/antsibull-core/pull/14)
+    type annotation instead of ``str`` for functions that accept a file name
+    (https://github.com/ansible-community/antsibull-core/pull/14).

--- a/src/antsibull_core/utils/io.py
+++ b/src/antsibull_core/utils/io.py
@@ -7,6 +7,7 @@
 
 import os
 import os.path
+import typing as t
 
 import aiofiles
 
@@ -14,10 +15,15 @@ from .. import app_context
 from ..logging import log
 
 
+if t.TYPE_CHECKING:
+    # TODO PY3.8: Use __future__.annotations instead of quoting annotations
+    # pylint:disable=unused-import
+    from _typeshed import StrOrBytesPath
+
 mlog = log.fields(mod=__name__)
 
 
-async def copy_file(source_path: str, dest_path: str) -> None:
+async def copy_file(source_path: "StrOrBytesPath", dest_path: "StrOrBytesPath") -> None:
     """
     Copy content from one file to another.
 
@@ -64,7 +70,7 @@ async def copy_file(source_path: str, dest_path: str) -> None:
     flog.debug('Leave')
 
 
-async def write_file(filename: str, content: str) -> None:
+async def write_file(filename: "StrOrBytesPath", content: str) -> None:
     flog = mlog.fields(func='write_file')
     flog.debug('Enter')
 
@@ -93,7 +99,7 @@ async def write_file(filename: str, content: str) -> None:
     flog.debug('Leave')
 
 
-async def read_file(filename: str, encoding: str = 'utf-8') -> str:
+async def read_file(filename: "StrOrBytesPath", encoding: str = 'utf-8') -> str:
     flog = mlog.fields(func='read_file')
     flog.debug('Enter')
 

--- a/src/antsibull_core/yaml.py
+++ b/src/antsibull_core/yaml.py
@@ -22,6 +22,11 @@ except ImportError:
     from yaml import SafeLoader as _SafeLoader
     from yaml import SafeDumper as _SafeDumper
 
+if t.TYPE_CHECKING:
+    # TODO PY3.8: Use __future__.annotations instead of quoting annotations
+    # pylint:disable=unused-import
+    from _typeshed import StrOrBytesPath
+
 
 def load_yaml_bytes(data: bytes) -> t.Any:
     """
@@ -30,7 +35,7 @@ def load_yaml_bytes(data: bytes) -> t.Any:
     return yaml.load(data, Loader=_SafeLoader)
 
 
-def load_yaml_file(path: str) -> t.Any:
+def load_yaml_file(path: "StrOrBytesPath") -> t.Any:
     """
     Load and parse YAML file ``path``.
     """
@@ -38,7 +43,7 @@ def load_yaml_file(path: str) -> t.Any:
         return yaml.load(stream, Loader=_SafeLoader)
 
 
-def store_yaml_file(path: str, content: t.Any) -> None:
+def store_yaml_file(path: "StrOrBytesPath", content: t.Any) -> None:
     """
     Store ``content`` as YAML file under ``path``.
     """


### PR DESCRIPTION
StrOrBytesPath encompasses str, bytes, and PathLike file names, which are valid inputs to open(). There's likely more of these that should be fixed, but this is some of them. I'd like to use pathlib in my source distribution code so that's my motivation here :).