### PR TITLE
typing: use simpler syntax where possible

### DIFF
--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -5,6 +5,9 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 
 """Functions for working with the ansible-core package."""
+
+from __future__ import annotations
+
 import ast
 import asyncio
 import os
@@ -56,7 +59,7 @@ class AnsibleCorePyPiClient:
         self.aio_session = aio_session
         self.pypi_server_url = pypi_server_url
 
-    async def _get_json(self, query_url: str) -> t.Dict[str, t.Any]:
+    async def _get_json(self, query_url: str) -> dict[str, t.Any]:
         """
         JSON data from a url with retries and return the data as python data structures.
         """
@@ -65,7 +68,7 @@ class AnsibleCorePyPiClient:
         return pkg_info
 
     @lru_cache(None)
-    async def get_release_info(self) -> t.Dict[str, t.Any]:
+    async def get_release_info(self) -> dict[str, t.Any]:
         """
         Retrieve information about releases of the ansible-core/ansible-base package from pypi.
 
@@ -89,7 +92,7 @@ class AnsibleCorePyPiClient:
 
         return release_info
 
-    async def get_versions(self) -> t.List[PypiVer]:
+    async def get_versions(self) -> list[PypiVer]:
         """
         Get the versions of the ansible-core package on pypi.
 
@@ -148,7 +151,7 @@ class AnsibleCorePyPiClient:
         return tar_filename
 
 
-def get_ansible_core_package_name(ansible_core_version: t.Union[str, PypiVer]) -> str:
+def get_ansible_core_package_name(ansible_core_version: str | PypiVer) -> str:
     """
     Returns the name of the minimal ansible package.
 
@@ -195,7 +198,7 @@ def _version_is_devel(version: PypiVer) -> bool:
     return bool(dev_version.match(version.public))
 
 
-def source_is_devel(ansible_core_source: t.Optional[str]) -> bool:
+def source_is_devel(ansible_core_source: str | None) -> bool:
     """
     :arg ansible_core_source: A path to an Ansible-core checkout or expanded sdist or None.
         This will be used instead of downloading an ansible-core package if the version matches
@@ -213,7 +216,7 @@ def source_is_devel(ansible_core_source: t.Optional[str]) -> bool:
     return _version_is_devel(source_version)
 
 
-def source_is_correct_version(ansible_core_source: t.Optional[str],
+def source_is_correct_version(ansible_core_source: str | None,
                               ansible_core_version: PypiVer) -> bool:
     """
     :arg ansible_core_source: A path to an Ansible-core checkout or expanded sdist or None.
@@ -303,7 +306,7 @@ async def create_sdist(source_dir: str, dest_dir: str) -> str:
 async def get_ansible_core(aio_session: 'aiohttp.client.ClientSession',
                            ansible_core_version: str,
                            tmpdir: str,
-                           ansible_core_source: t.Optional[str] = None) -> str:
+                           ansible_core_source: str | None = None) -> str:
     """
     Create an ansible-core directory of the requested version.
 

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -107,6 +107,7 @@ import argparse
 import contextvars
 import typing as t
 from contextlib import contextmanager
+from collections.abc import Iterable, Mapping
 
 from .schemas.context import AppContext, LibContext
 from .vendored.collections import ImmutableDict
@@ -193,12 +194,12 @@ class ContextReturn(t.Generic[AppContextT]):
             return self.cfg
         raise IndexError('tuple index out of range')
 
-    def __iter__(self) -> t.Iterable:
+    def __iter__(self) -> Iterable:
         return (self.app_ctx, self.lib_ctx, self.args, self.cfg).__iter__()
 
 
 def _extract_context_values(known_fields, args: argparse.Namespace | None,
-                            cfg: t.Mapping = ImmutableDict()) -> dict:
+                            cfg: Mapping = ImmutableDict()) -> dict:
 
     context_values = {}
     if cfg:
@@ -221,7 +222,7 @@ def _extract_context_values(known_fields, args: argparse.Namespace | None,
 
 @t.overload
 def create_contexts(args: argparse.Namespace | None = None,
-                    cfg: t.Mapping = ImmutableDict(),
+                    cfg: Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     ) -> ContextReturn[AppContext]:
     ...
@@ -229,7 +230,7 @@ def create_contexts(args: argparse.Namespace | None = None,
 
 @t.overload
 def create_contexts(args: argparse.Namespace | None = None,
-                    cfg: t.Mapping = ImmutableDict(),
+                    cfg: Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     *,
                     app_context_model: type[AppContextT],
@@ -238,7 +239,7 @@ def create_contexts(args: argparse.Namespace | None = None,
 
 
 def create_contexts(args: argparse.Namespace | None = None,
-                    cfg: t.Mapping = ImmutableDict(),
+                    cfg: Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     *,
                     app_context_model=AppContext,

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -172,11 +172,11 @@ class ContextReturn(t.Generic[AppContextT]):
     app_ctx: AppContextT
     lib_ctx: LibContext
     args: argparse.Namespace
-    cfg: t.Dict
+    cfg: dict
 
     # pylint: disable-next=redefined-outer-name
     def __init__(self, app_ctx: AppContextT, lib_ctx: LibContext,
-                 args: argparse.Namespace, cfg: t.Dict):
+                 args: argparse.Namespace, cfg: dict):
         self.app_ctx = app_ctx
         self.lib_ctx = lib_ctx
         self.args = args
@@ -197,8 +197,8 @@ class ContextReturn(t.Generic[AppContextT]):
         return (self.app_ctx, self.lib_ctx, self.args, self.cfg).__iter__()
 
 
-def _extract_context_values(known_fields, args: t.Optional[argparse.Namespace],
-                            cfg: t.Mapping = ImmutableDict()) -> t.Dict:
+def _extract_context_values(known_fields, args: argparse.Namespace | None,
+                            cfg: t.Mapping = ImmutableDict()) -> dict:
 
     context_values = {}
     if cfg:
@@ -220,7 +220,7 @@ def _extract_context_values(known_fields, args: t.Optional[argparse.Namespace],
 
 
 @t.overload
-def create_contexts(args: t.Optional[argparse.Namespace] = None,
+def create_contexts(args: argparse.Namespace | None = None,
                     cfg: t.Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     ) -> ContextReturn[AppContext]:
@@ -228,16 +228,16 @@ def create_contexts(args: t.Optional[argparse.Namespace] = None,
 
 
 @t.overload
-def create_contexts(args: t.Optional[argparse.Namespace] = None,
+def create_contexts(args: argparse.Namespace | None = None,
                     cfg: t.Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     *,
-                    app_context_model: t.Type[AppContextT],
+                    app_context_model: type[AppContextT],
                     ) -> ContextReturn[AppContextT]:
     ...
 
 
-def create_contexts(args: t.Optional[argparse.Namespace] = None,
+def create_contexts(args: argparse.Namespace | None = None,
                     cfg: t.Mapping = ImmutableDict(),
                     use_extra: bool = True,
                     *,
@@ -328,7 +328,7 @@ def _copy_app_context() -> AppContext:
 
 
 @contextmanager
-def lib_context(new_context: t.Optional[LibContext] = None) -> t.Generator[LibContext, None, None]:
+def lib_context(new_context: LibContext | None = None) -> t.Generator[LibContext, None, None]:
     """
     Set up a new lib_context.
 
@@ -374,7 +374,7 @@ def app_context(new_context=None):
 
 @contextmanager
 def app_and_lib_context(context_data: ContextReturn[AppContextT]
-                        ) -> t.Generator[t.Tuple[AppContextT, LibContext], None, None]:
+                        ) -> t.Generator[tuple[AppContextT, LibContext], None, None]:
     """
     Set the app and lib context at the same time.
 

--- a/src/antsibull_core/args.py
+++ b/src/antsibull_core/args.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Argument parsing helpers."""
 
+from __future__ import annotations
+
 import argparse
 import os.path
 

--- a/src/antsibull_core/collections.py
+++ b/src/antsibull_core/collections.py
@@ -7,7 +7,6 @@
 import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import List
 
 import sh
 
@@ -18,7 +17,7 @@ class CollectionFormatError(Exception):
     pass
 
 
-async def install_together(collection_tarballs: List[str],
+async def install_together(collection_tarballs: list[str],
                            ansible_collections_dir: str) -> None:
     loop = asyncio.get_running_loop()
     lib_ctx = app_context.lib_ctx.get()
@@ -42,9 +41,9 @@ async def install_together(collection_tarballs: List[str],
     await asyncio.gather(*installers)
 
 
-async def install_separately(collection_tarballs: List[str], collection_dir: str) -> List[str]:
+async def install_separately(collection_tarballs: list[str], collection_dir: str) -> list[str]:
     installers = []
-    collection_dirs: List[str] = []
+    collection_dirs: list[str] = []
 
     if not collection_tarballs:
         return collection_dirs

--- a/src/antsibull_core/collections.py
+++ b/src/antsibull_core/collections.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Functions to deal with collections on the local system"""
+
+from __future__ import annotations
+
 import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor

--- a/src/antsibull_core/config.py
+++ b/src/antsibull_core/config.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Functions to handle config files."""
 
+from __future__ import annotations
+
 import os.path
 import typing as t
 
@@ -29,7 +31,7 @@ class ConfigError(Exception):
     pass
 
 
-def find_config_files(conf_files: t.Iterable[str]) -> t.List[str]:
+def find_config_files(conf_files: t.Iterable[str]) -> list[str]:
     """
     Find all config files that exist.
 
@@ -75,8 +77,8 @@ def read_config(filename: str) -> ConfigModel:
     return raw_config_data
 
 
-def validate_config(config: t.Mapping, filenames: t.List[str],
-                    app_context_model: t.Type[AppContext]) -> None:
+def validate_config(config: t.Mapping, filenames: list[str],
+                    app_context_model: type[AppContext]) -> None:
     """
     Validate configuration.
 
@@ -116,8 +118,8 @@ def _load_config_file(filename: str) -> t.Mapping:
             f"Error while parsing configuration from {filename}:\n{exc}") from exc
 
 
-def load_config(conf_files: t.Union[t.Iterable[str], str, None] = None,
-                app_context_model: t.Type[AppContext] = AppContext) -> t.Dict:
+def load_config(conf_files: t.Iterable[str] | str | None = None,
+                app_context_model: type[AppContext] = AppContext) -> dict:
     """
     Load configuration.
 
@@ -146,7 +148,7 @@ def load_config(conf_files: t.Union[t.Iterable[str], str, None] = None,
                 explicit_files=explicit_files).debug('found config files')
 
     flog.debug('loading implicit config files')
-    cfg: t.Dict = {}
+    cfg: dict = {}
     for filename in implicit_files:
         cfg.update(_load_config_file(filename))
 

--- a/src/antsibull_core/config.py
+++ b/src/antsibull_core/config.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import os.path
-import typing as t
+from collections.abc import Iterable, Mapping
 
 import perky  # type: ignore[import]
 import pydantic as p
@@ -31,7 +31,7 @@ class ConfigError(Exception):
     pass
 
 
-def find_config_files(conf_files: t.Iterable[str]) -> list[str]:
+def find_config_files(conf_files: Iterable[str]) -> list[str]:
     """
     Find all config files that exist.
 
@@ -77,7 +77,7 @@ def read_config(filename: str) -> ConfigModel:
     return raw_config_data
 
 
-def validate_config(config: t.Mapping, filenames: list[str],
+def validate_config(config: Mapping, filenames: list[str],
                     app_context_model: type[AppContext]) -> None:
     """
     Validate configuration.
@@ -104,7 +104,7 @@ def validate_config(config: t.Mapping, filenames: list[str],
             f"Error while parsing configuration from {', '.join(filenames)}:\n{exc}") from exc
 
 
-def _load_config_file(filename: str) -> t.Mapping:
+def _load_config_file(filename: str) -> Mapping:
     """
     Load configuration from one file and return the raw data.
     """
@@ -118,7 +118,7 @@ def _load_config_file(filename: str) -> t.Mapping:
             f"Error while parsing configuration from {filename}:\n{exc}") from exc
 
 
-def load_config(conf_files: t.Iterable[str] | str | None = None,
+def load_config(conf_files: Iterable[str] | str | None = None,
                 app_context_model: type[AppContext] = AppContext) -> dict:
     """
     Load configuration.

--- a/src/antsibull_core/dependency_files.py
+++ b/src/antsibull_core/dependency_files.py
@@ -17,6 +17,7 @@ don't want to install backwards incompatible collections until the next major An
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Mapping
 
 from packaging.version import Version as PypiVer
 
@@ -114,7 +115,7 @@ class DepsFile:
 
     def write(self, ansible_version: str | PypiVer,
               ansible_core_version: str | PypiVer,
-              included_versions: t.Mapping[str, str] | t.Mapping[str, SemVer],
+              included_versions: Mapping[str, str] | Mapping[str, SemVer],
               python_requires: str | None = None) -> None:
         """
         Write a list of all the dependent collections included in this Ansible release.
@@ -157,8 +158,8 @@ class BuildFile:
         """Parse the build from a dependency file."""
         return _parse_name_version_spec_file(self.filename)
 
-    def write(self, ansible_version: 'PypiVer', ansible_core_version: str,
-              dependencies: t.Mapping[str, 'SemVer'],
+    def write(self, ansible_version: PypiVer, ansible_core_version: str,
+              dependencies: Mapping[str, SemVer],
               python_requires: str | None = None) -> None:
         """
         Write a build dependency file.

--- a/src/antsibull_core/dependency_files.py
+++ b/src/antsibull_core/dependency_files.py
@@ -14,25 +14,27 @@ When we initially build an Ansible major release, we'll use certain versions of 
 don't want to install backwards incompatible collections until the next major Ansible release.
 """
 
-from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional, Union
+from __future__ import annotations
+
+import typing as t
 
 from packaging.version import Version as PypiVer
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from semantic_version import Version as SemVer
 
 
-class DependencyFileData(NamedTuple):
+class DependencyFileData(t.NamedTuple):
     ansible_version: str
     ansible_core_version: str
-    deps: Dict[str, str]
+    deps: dict[str, str]
 
 
 class InvalidFileFormat(Exception):
     pass
 
 
-def parse_pieces_file(pieces_file: str) -> List[str]:
+def parse_pieces_file(pieces_file: str) -> list[str]:
     with open(pieces_file, 'rb') as f:
         contents = f.read()
 
@@ -44,9 +46,9 @@ def parse_pieces_file(pieces_file: str) -> List[str]:
 
 
 def _parse_name_version_spec_file(filename: str) -> DependencyFileData:
-    deps: Dict[str, str] = {}
-    ansible_core_version: Optional[str] = None
-    ansible_version: Optional[str] = None
+    deps: dict[str, str] = {}
+    ansible_core_version: str | None = None
+    ansible_version: str | None = None
 
     for line in parse_pieces_file(filename):
         record = [entry.strip() for entry in line.split(':', 1)]
@@ -110,10 +112,10 @@ class DepsFile:
         """Parse the deps from a dependency file."""
         return _parse_name_version_spec_file(self.filename)
 
-    def write(self, ansible_version: Union[str, 'PypiVer'],
-              ansible_core_version: Union[str, 'PypiVer'],
-              included_versions: Union[Mapping[str, str], Mapping[str, 'SemVer']],
-              python_requires: Optional[str] = None) -> None:
+    def write(self, ansible_version: str | PypiVer,
+              ansible_core_version: str | PypiVer,
+              included_versions: t.Mapping[str, str] | t.Mapping[str, SemVer],
+              python_requires: str | None = None) -> None:
         """
         Write a list of all the dependent collections included in this Ansible release.
 
@@ -156,8 +158,8 @@ class BuildFile:
         return _parse_name_version_spec_file(self.filename)
 
     def write(self, ansible_version: 'PypiVer', ansible_core_version: str,
-              dependencies: Mapping[str, 'SemVer'],
-              python_requires: Optional[str] = None) -> None:
+              dependencies: t.Mapping[str, 'SemVer'],
+              python_requires: str | None = None) -> None:
         """
         Write a build dependency file.
 

--- a/src/antsibull_core/filesystem.py
+++ b/src/antsibull_core/filesystem.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
+from __future__ import annotations
+
 import sh
 
 try:

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -65,7 +65,7 @@ class GalaxyClient:
         self.aio_session = aio_session
         self.params = {'format': 'json'}
 
-    async def _get_galaxy_versions(self, versions_url: str) -> t.List[str]:
+    async def _get_galaxy_versions(self, versions_url: str) -> list[str]:
         """
         Retrieve the complete list of versions for a collection from a galaxy endpoint.
 
@@ -93,7 +93,7 @@ class GalaxyClient:
 
         return versions
 
-    async def get_versions(self, collection: str) -> t.List[str]:
+    async def get_versions(self, collection: str) -> list[str]:
         """
         Retrieve all versions of a collection on Galaxy.
 
@@ -105,7 +105,7 @@ class GalaxyClient:
         retval = await self._get_galaxy_versions(galaxy_url)
         return retval
 
-    async def get_info(self, collection: str) -> t.Dict[str, t.Any]:
+    async def get_info(self, collection: str) -> dict[str, t.Any]:
         """
         Retrieve information about the collection on Galaxy.
 
@@ -131,7 +131,7 @@ class GalaxyClient:
         return collection_info
 
     async def get_release_info(self, collection: str,
-                               version: t.Union[str, semver.Version]) -> t.Dict[str, t.Any]:
+                               version: str | semver.Version) -> dict[str, t.Any]:
         """
         Retrive information about a specific version of a collection.
 
@@ -213,7 +213,7 @@ class CollectionDownloader(GalaxyClient):
     def __init__(self, aio_session: aiohttp.client.ClientSession,
                  download_dir: str,
                  galaxy_server: str = _GALAXY_SERVER_URL,
-                 collection_cache: t.Optional[str] = None) -> None:
+                 collection_cache: str | None = None) -> None:
         """
         Create an object to download collections from galaxy.
 
@@ -227,9 +227,9 @@ class CollectionDownloader(GalaxyClient):
         """
         super().__init__(aio_session, galaxy_server)
         self.download_dir = download_dir
-        self.collection_cache: t.Final[t.Optional[str]] = collection_cache
+        self.collection_cache: t.Final[str | None] = collection_cache
 
-    async def download(self, collection: str, version: t.Union[str, semver.Version], ) -> str:
+    async def download(self, collection: str, version: str | semver.Version, ) -> str:
         """
         Download a collection.
 

--- a/src/antsibull_core/logging.py
+++ b/src/antsibull_core/logging.py
@@ -200,6 +200,9 @@ Here's a sample of the relevant portions of an antsibull command to show how thi
 Once those steps are taken, any further logging calls will obey the user's configuration.
 
 """
+
+from __future__ import annotations
+
 import os
 
 import twiggy  # type: ignore[import]

--- a/src/antsibull_core/schemas/config.py
+++ b/src/antsibull_core/schemas/config.py
@@ -7,6 +7,7 @@
 
 import os.path
 import typing as t
+from collections.abc import Callable, Mapping, MutableMapping, MutableSequence, Sequence
 
 import pydantic as p
 import twiggy.formats  # type: ignore[import]
@@ -39,29 +40,29 @@ class BaseModel(p.BaseModel):
 
 # pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogFiltersModel(BaseModel):
-    filter: t.Union[str, t.Callable]
-    args: t.Sequence[t.Any] = []
-    kwargs: t.Mapping[str, t.Any] = {}
+    filter: t.Union[str, Callable]
+    args: Sequence[t.Any] = []
+    kwargs: Mapping[str, t.Any] = {}
 
 
 # pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogEmitterModel(BaseModel):
     output_name: str
     level: str = LEVEL_CHOICES_F
-    filters: t.List[LogFiltersModel] = []
+    filters: list[LogFiltersModel] = []
 
 
 # pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogOutputModel(BaseModel):
-    output: t.Union[str, t.Callable]
-    args: t.Sequence[t.Any] = []
-    format: t.Union[str, t.Callable] = twiggy.formats.line_format
-    kwargs: t.Mapping[str, t.Any] = {}
+    output: t.Union[str, Callable]
+    args: Sequence[t.Any] = []
+    format: t.Union[str, Callable] = twiggy.formats.line_format
+    kwargs: Mapping[str, t.Any] = {}
 
     @p.validator('args')
     # pylint:disable=no-self-argument
-    def expand_home_dir_args(cls, args_field: t.MutableSequence,
-                             values: t.Mapping) -> t.MutableSequence:
+    def expand_home_dir_args(cls, args_field: MutableSequence,
+                             values: Mapping) -> MutableSequence:
         """Expand tilde in the arguments of specific outputs."""
         if values['output'] in ('twiggy.outputs.FileOutput', twiggy.outputs.FileOutput):
             if args_field:
@@ -70,8 +71,8 @@ class LogOutputModel(BaseModel):
 
     @p.validator('kwargs')
     # pylint:disable=no-self-argument
-    def expand_home_dir_kwargs(cls, kwargs_field: t.MutableMapping,
-                               values: t.Mapping) -> t.MutableMapping:
+    def expand_home_dir_kwargs(cls, kwargs_field: MutableMapping,
+                               values: Mapping) -> MutableMapping:
         """Expand tilde in the keyword arguments of specific outputs."""
         if values['output'] in ('twiggy.outputs.FileOutput', twiggy.outputs.FileOutput):
             if 'name' in kwargs_field:
@@ -80,9 +81,9 @@ class LogOutputModel(BaseModel):
 
 
 class LoggingModel(BaseModel):
-    emitters: t.Optional[t.Dict[str, LogEmitterModel]] = {}
+    emitters: t.Optional[dict[str, LogEmitterModel]] = {}
     incremental: bool = False
-    outputs: t.Optional[t.Dict[str, LogOutputModel]] = {}
+    outputs: t.Optional[dict[str, LogOutputModel]] = {}
     version: str = VERSION_CHOICES_F
 
 

--- a/src/antsibull_core/schemas/validators.py
+++ b/src/antsibull_core/schemas/validators.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2021, Toshio Kuratomi
 """Pydantic validators."""
 
+from __future__ import annotations
+
 import os.path
 
 

--- a/src/antsibull_core/tarball.py
+++ b/src/antsibull_core/tarball.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Functions for working with tarballs."""
+
+from __future__ import annotations
+
 import re
 
 import sh

--- a/src/antsibull_core/utils/collections.py
+++ b/src/antsibull_core/utils/collections.py
@@ -32,7 +32,7 @@ def is_sequence(obj: t.Any, include_string: bool = False) -> bool:
 
 
 def compare_all_but(dict_a: t.Mapping, dict_b: t.Mapping,
-                    keys_to_ignore: t.Optional[t.Iterable] = None) -> bool:
+                    keys_to_ignore: t.Iterable | None = None) -> bool:
     """
     Compare two dictionaries, with the possibility to ignore some fields.
 
@@ -64,7 +64,7 @@ def compare_all_but(dict_a: t.Mapping, dict_b: t.Mapping,
     return True
 
 
-def _make_contained_containers_immutable(obj: t.Union[Set, Sequence]) -> t.List:
+def _make_contained_containers_immutable(obj: Set | Sequence) -> t.List:
     """
     Make contained containers into immutable containers.
 

--- a/src/antsibull_core/utils/collections.py
+++ b/src/antsibull_core/utils/collections.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import typing as t
-from collections.abc import Container, Mapping, Sequence, Set
+from collections.abc import Container, Iterable, Mapping, Sequence, Set
 
 from ..vendored.collections import ImmutableDict
 
@@ -33,8 +33,8 @@ def is_sequence(obj: t.Any, include_string: bool = False) -> bool:
     return False
 
 
-def compare_all_but(dict_a: t.Mapping, dict_b: t.Mapping,
-                    keys_to_ignore: t.Iterable | None = None) -> bool:
+def compare_all_but(dict_a: Mapping, dict_b: Mapping,
+                    keys_to_ignore: Iterable | None = None) -> bool:
     """
     Compare two dictionaries, with the possibility to ignore some fields.
 
@@ -66,7 +66,7 @@ def compare_all_but(dict_a: t.Mapping, dict_b: t.Mapping,
     return True
 
 
-def _make_contained_containers_immutable(obj: Set | Sequence) -> t.List:
+def _make_contained_containers_immutable(obj: Set | Sequence) -> list:
     """
     Make contained containers into immutable containers.
 
@@ -127,7 +127,7 @@ class ContextDict(ImmutableDict):
         yield cls.validate_and_convert
 
     @classmethod
-    def validate_and_convert(cls, value: t.Mapping) -> 'ContextDict':
+    def validate_and_convert(cls, value: Mapping) -> 'ContextDict':
         if isinstance(value, ContextDict):
             # optimization.  If it's already an ImmutableContext, we don't need to recursively
             # convert things to immutable again.

--- a/src/antsibull_core/utils/collections.py
+++ b/src/antsibull_core/utils/collections.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """General functions for working with python collections and classes for new data types."""
 
+from __future__ import annotations
+
 import typing as t
 from collections.abc import Container, Mapping, Sequence, Set
 

--- a/src/antsibull_core/utils/hashing.py
+++ b/src/antsibull_core/utils/hashing.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Functions to help with hashing."""
 
+from __future__ import annotations
+
 import hashlib
 
 import aiofiles

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -22,17 +22,17 @@ from ..logging import log
 mlog = log.fields(mod=__name__)
 
 
-def _format_call(command: str, args: t.Tuple[t.Any, ...], kwargs: t.Mapping[str, t.Any]) -> str:
+def _format_call(command: str, args: tuple[t.Any, ...], kwargs: t.Mapping[str, t.Any]) -> str:
     arguments = [repr(a) for a in args] + [f'{k}={repr(v)}' for k, v in kwargs.items()]
     return f'aio_session.{command}({", ".join(arguments)})'
 
 
 class RetryGetManager:
-    response: t.Optional[aiohttp.ClientResponse]
+    response: aiohttp.ClientResponse | None
 
     def __init__(self,
                  aio_session: aiohttp.client.ClientSession,
-                 args: t.Tuple[t.Any, ...],
+                 args: tuple[t.Any, ...],
                  kwargs: t.Mapping[str, t.Any],
                  max_retries: int,
                  acceptable_error_codes: t.Iterable[int],
@@ -98,8 +98,8 @@ class RetryGetManager:
 
 def retry_get(aio_session: aiohttp.client.ClientSession,
               *args,
-              acceptable_error_codes: t.Optional[t.Iterable[int]] = None,
-              max_retries: t.Optional[int] = None,
+              acceptable_error_codes: t.Iterable[int] | None = None,
+              max_retries: int | None = None,
               **kwargs) -> t.AsyncContextManager[aiohttp.ClientResponse]:
     # Handle default value for max_retries
     lib_ctx = app_context.lib_ctx.get()

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -12,6 +12,7 @@ import math
 import random
 import typing as t
 import warnings
+from collections.abc import Iterable, Mapping
 
 import aiohttp
 
@@ -22,7 +23,7 @@ from ..logging import log
 mlog = log.fields(mod=__name__)
 
 
-def _format_call(command: str, args: tuple[t.Any, ...], kwargs: t.Mapping[str, t.Any]) -> str:
+def _format_call(command: str, args: tuple[t.Any, ...], kwargs: Mapping[str, t.Any]) -> str:
     arguments = [repr(a) for a in args] + [f'{k}={repr(v)}' for k, v in kwargs.items()]
     return f'aio_session.{command}({", ".join(arguments)})'
 
@@ -33,9 +34,9 @@ class RetryGetManager:
     def __init__(self,
                  aio_session: aiohttp.client.ClientSession,
                  args: tuple[t.Any, ...],
-                 kwargs: t.Mapping[str, t.Any],
+                 kwargs: Mapping[str, t.Any],
                  max_retries: int,
-                 acceptable_error_codes: t.Iterable[int],
+                 acceptable_error_codes: Iterable[int],
                  ):
         self.aio_session = aio_session
         self.args = args
@@ -98,7 +99,7 @@ class RetryGetManager:
 
 def retry_get(aio_session: aiohttp.client.ClientSession,
               *args,
-              acceptable_error_codes: t.Iterable[int] | None = None,
+              acceptable_error_codes: Iterable[int] | None = None,
               max_retries: int | None = None,
               **kwargs) -> t.AsyncContextManager[aiohttp.ClientResponse]:
     # Handle default value for max_retries

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -5,14 +5,15 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Functionality to work with a venv."""
 
+from __future__ import annotations
+
 import os
-import typing as t
 import venv
 
 import sh
 
 
-def get_clean_environment() -> t.Dict[str, str]:
+def get_clean_environment() -> dict[str, str]:
     env = os.environ.copy()
     try:
         del env['PYTHONPATH']


### PR DESCRIPTION
See https://github.com/ansible-community/antsibull-core/pull/18#issuecomment-1340037669

I didn't change the files in antsibull_core.schemas since Pydantic needs runtime access to the type definitions.

I also didn't change `typing.Mapping` and friends to `collections.abc.Mapping` since it's more to type :)