### PR TITLE
CI: exclude never executed code from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,20 @@ line_length = 100
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.coverage.report]
+# https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
+# These should use single quotes in TOML, as they're regular expressions.
+exclude_lines = [
+    'pragma: no cover',
+    'def __repr__',
+    'raise NotImplementedError',
+    'if __name__ == .__main__.:',
+    'if TYPE_CHECKING:',
+    'if t.TYPE_CHECKING:',
+    'class .*\bProtocol\):',
+    '@(abc\.)?abstractmethod',
+]
+
 [tool.coverage.paths]
 source = [
     "src",


### PR DESCRIPTION
Things like `if TYPE_CHECKING` which we use various places in the
project artificially lower the coverage percentage.
