### PR TITLE
venv: prepare for sh removal and add tests

### DIFF
--- a/changelogs/fragments/50-new-venv.yaml
+++ b/changelogs/fragments/50-new-venv.yaml
@@ -1,0 +1,18 @@
+---
+deprecated_features:
+  - Deprecate the ``get_command()`` methods of ``antsibull_core.venv.VenvRunner` and ``antsibull_core.venv.FakeVenvRunner``.
+    These methods will be removed in antsibull-core 3.0.0.
+    Use the new ``log_run()`` and ``async_run()`` methods instead
+    (https://github.com/ansible-community/antsibull-core/pull/50).
+
+breaking_changes:
+  - The ``install_package()`` method of ``antsibull_core.venv.VenvRunner`` now
+    returns a ``subprocess.CompletedProcess` object instead of an
+    ``sh.RunningCommand``.
+    The rest of the function signature remains the same.
+    Most callers should not need to access the output to begin with
+    (https://github.com/ansible-community/antsibull-core/pull/50).
+minor_changes:
+  - Add ``async_log_run()`` and ``log_run()`` methods to ``antsibull_core.venv.VenvRunner` and ``antsibull_core.venv.FakeVenvRunner``.
+    These should be used instead of ``get_command()``
+    (https://github.com/ansible-community/antsibull-core/pull/50).

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -11,7 +11,7 @@ import asyncio
 import os
 import venv
 from collections.abc import MutableSequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import sh
 
@@ -167,7 +167,7 @@ class FakeVenvRunner:
         return sh.Command(executable_name)
 
     @staticmethod
-    def install_package(package_name: str) -> sh.RunningCommand:
+    def install_package(package_name: str) -> NoReturn:
         """
         Install a python package into the venv.
 

--- a/tests/functional/test_venv.py
+++ b/tests/functional/test_venv.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import os.path
+from unittest import mock
+
+import pytest
+
+from antsibull_core import subprocess_util
+from antsibull_core.venv import FakeVenvRunner, VenvRunner, get_clean_environment
+
+
+def test_venv_clean_env(monkeypatch):
+    monkeypatch.setenv('PYTHONPATH', '/jfjfjfjfjfjfjfjfj')
+    assert 'PYTHONPATH' not in get_clean_environment()
+
+
+def test_venv_run_init(tmp_path):
+    with mock.patch('antsibull_core.subprocess_util.async_log_run') as log_run:
+        runner = VenvRunner('asdfgh', tmp_path)
+        assert runner.name == 'asdfgh'
+        assert runner.top_dir == tmp_path
+        assert runner.venv_dir == str(tmp_path / 'asdfgh')
+        pip = os.path.join(runner.venv_dir, 'bin', 'pip')
+        log_run.assert_called_once_with(
+            [pip, 'install', '--upgrade', 'pip'],
+            None,
+            None,
+            'debug',
+            True,
+            env=get_clean_environment(),
+        )
+
+
+def test_venv_log_run_error(tmp_path):
+    runner = VenvRunner('zxcvb', tmp_path)
+    echo = os.path.join(runner.venv_dir, 'bin', 'echo')
+    with pytest.raises(ValueError, match=rf'^{echo!r} does not exist!'):
+        runner.log_run(['echo', "This won't work!"])
+
+
+def test_venv_log_run_error2(tmp_path):
+    runner = VenvRunner('zxcvb', tmp_path)
+    echo = '/usr/bin/echo'
+    with pytest.raises(ValueError, match=rf'^{echo!r} must not be an absolute path!'):
+        runner.log_run([echo, "This also won't work!"])


### PR DESCRIPTION
- Deprecate the `get_command` methods on VenvRunner and FakeVenvRunner
- Add new `async_log_run` and `log_run` methods to replace the former.
  These work the same as their counterparts in
  `antsibull_core.subprocess_util`, but the VenvRunner version enforces
  a clean environment and requires paths to be installed in the venv.
