### PR TITLE
Allow to handle UTF-8 decoding errors

### DIFF
--- a/src/antsibull_core/subprocess_util.py
+++ b/src/antsibull_core/subprocess_util.py
@@ -26,14 +26,15 @@ mlog = log.fields(mod=__name__)
 
 
 async def _stream_log(
-    name: str, callback: Callable[[str], Any] | None, stream: asyncio.StreamReader
+    name: str, callback: Callable[[str], Any] | None, stream: asyncio.StreamReader,
+    decode_error_handling: str,
 ) -> str:
     line = await stream.readline()
     lines = []
     while True:
         if not line:
             break
-        text = line.decode('utf-8', errors='surrogateescape')
+        text = line.decode('utf-8', errors=decode_error_handling)
         if callback:
             callback(f'{name}: {text.strip()}')
         lines.append(text)
@@ -47,6 +48,7 @@ async def async_log_run(
     stdout_loglevel: str | None = None,
     stderr_loglevel: str | None = 'debug',
     check: bool = True,
+    decode_error_handling: str = 'surrogateescape',
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """
@@ -64,6 +66,8 @@ async def async_log_run(
     :param check:
         Whether to raise a `subprocess.CalledProcessError` when the
         command returns a non-zero exit code
+    :param decode_error_handling:
+        How to handle UTF-8 decoding errors. Default is ``surrogateescape``.
     """
     logger = logger or mlog
     stdout_logfunc: Callable[[str], Any] | None = None
@@ -81,12 +85,14 @@ async def async_log_run(
         # proc.stdout and proc.stderr won't be None with PIPE, hence the cast()
         asyncio.create_task(
             _stream_log(
-                'stdout', stdout_logfunc, cast(asyncio.StreamReader, proc.stdout)
+                'stdout', stdout_logfunc, cast(asyncio.StreamReader, proc.stdout),
+                decode_error_handling=decode_error_handling,
             )
         ),
         asyncio.create_task(
             _stream_log(
-                'stderr', stderr_logfunc, cast(asyncio.StreamReader, proc.stderr)
+                'stderr', stderr_logfunc, cast(asyncio.StreamReader, proc.stderr),
+                decode_error_handling=decode_error_handling,
             )
         ),
     )

--- a/src/antsibull_core/subprocess_util.py
+++ b/src/antsibull_core/subprocess_util.py
@@ -33,7 +33,7 @@ async def _stream_log(
     while True:
         if not line:
             break
-        text = line.decode('utf-8')
+        text = line.decode('utf-8', errors='surrogateescape')
         if callback:
             callback(f'{name}: {text.strip()}')
         lines.append(text)

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -101,6 +101,8 @@ class VenvRunner:
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',
         check: bool = True,
+        *,
+        errors: str = 'strict',
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """
@@ -118,7 +120,7 @@ class VenvRunner:
             raise ValueError(f'{path!r} does not exist!')
         args[0] = path
         return await subprocess_util.async_log_run(
-            args, logger, stdout_loglevel, stderr_loglevel, check, **kwargs
+            args, logger, stdout_loglevel, stderr_loglevel, check, errors=errors, **kwargs
         )
 
     def log_run(
@@ -128,6 +130,8 @@ class VenvRunner:
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',
         check: bool = True,
+        *,
+        errors: str = 'strict',
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """
@@ -135,7 +139,7 @@ class VenvRunner:
         """
         return asyncio.run(
             self.async_log_run(
-                args, logger, stdout_loglevel, stderr_loglevel, check, **kwargs
+                args, logger, stdout_loglevel, stderr_loglevel, check, errors=errors, **kwargs
             )
         )
 

--- a/tests/functional/test_venv.py
+++ b/tests/functional/test_venv.py
@@ -30,6 +30,7 @@ def test_venv_run_init(tmp_path):
             None,
             'debug',
             True,
+            errors='strict',
             env=get_clean_environment(),
         )
 


### PR DESCRIPTION
Most code that decodes stdout/stderr uses `decode('utf-8', errors='surrogateescape')`. So let's also use that in the library code.