### PR TITLE
Re-add doc_parsing_backend to library context

### DIFF
--- a/changelogs/fragments/54-config.yml
+++ b/changelogs/fragments/54-config.yml
@@ -1,2 +1,4 @@
 breaking_changes:
   - "Remove ``breadcrumbs``, ``indexes``, and ``use_html_blobs`` from global antsibull config handling. These options are only used by antsibull-docs, which already validates them itself (https://github.com/ansible-community/antsibull-core/pull/54)."
+deprecated_features:
+  - "The ``doc_parsing_backend`` option from the library context is deprecated and will be removed in antsibull-core 3.0.0. Applications that need it, such as antsibull-docs, must ensure they allow and validate this option themselves (https://github.com/ansible-community/antsibull-core/pull/59)."

--- a/changelogs/fragments/54-config.yml
+++ b/changelogs/fragments/54-config.yml
@@ -1,2 +1,2 @@
 breaking_changes:
-  - "Remove ``breadcrumbs``, ``doc_parsing_backend``, ``indexes``, and ``use_html_blobs`` from global antsibull config handling. These options are only used by antsibull-docs, which already validates them itself (https://github.com/ansible-community/antsibull-core/pull/54)."
+  - "Remove ``breadcrumbs``, ``indexes``, and ``use_html_blobs`` from global antsibull config handling. These options are only used by antsibull-docs, which already validates them itself (https://github.com/ansible-community/antsibull-core/pull/54)."

--- a/src/antsibull_core/schemas/config.py
+++ b/src/antsibull_core/schemas/config.py
@@ -18,6 +18,10 @@ from .validators import convert_none, convert_path
 #: Valid choices for a logging level field
 LEVEL_CHOICES_F = p.Field(..., regex='^(CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG|DISABLED)$')
 
+#: Valid choices for a logging level field
+_DOC_PARSING_BACKEND_CHOICES_F = p.Field(
+    'ansible-internal', regex='^(auto|ansible-doc|ansible-core-2.13|ansible-internal)$')
+
 #: Valid choice of the logging version field
 VERSION_CHOICES_F = p.Field(..., regex=r'1\.0')
 
@@ -117,6 +121,8 @@ class ConfigModel(BaseModel):
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     ansible_base_url: p.HttpUrl = 'https://github.com/ansible/ansible'  # type: ignore[assignment]
     chunksize: int = 4096
+    # DEPRECATED: doc_parsing_backend will be removed in antsibull-core 3.0.0
+    doc_parsing_backend: str = _DOC_PARSING_BACKEND_CHOICES_F
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     galaxy_url: p.HttpUrl = 'https://galaxy.ansible.com/'  # type: ignore[assignment]
     logging_cfg: LoggingModel = DEFAULT_LOGGING_CONFIG

--- a/src/antsibull_core/schemas/context.py
+++ b/src/antsibull_core/schemas/context.py
@@ -84,9 +84,18 @@ class LibContext(BaseModel):
         disable.
     :ivar max_retries: Maximum number of times to retry an http request (in case of timeouts and
         other transient problems.
+    :ivar doc_parsing_backend: The backend to use for parsing the documentation strings from
+        plugins.  This is DEPRECATED and will be removed from the library context in
+        antsibull-core 3.0.0.
+        'auto' selects a backend depending on the ansible-core version.
+        'ansible-internal' is the fastest, but does not work with ansible-core 2.13+.
+        'ansible-core-2.13' is also very fast, but requires ansible-core 2.13+.
+        'ansible-doc' exists in case of problems with the ansible-internal backend.
     """
 
     chunksize: int = 4096
+    # DEPRECATED: doc_parsing_backend will be removed in antsibull-core 3.0.0
+    doc_parsing_backend: str = 'auto'
     max_retries: int = 10
     process_max: t.Optional[int] = None
     thread_max: int = 8


### PR DESCRIPTION
This reverts parts of commit 81cd1287c9c6980c5cf376ac1b37fb681749b420 from #54, since it broke compatibility.