### PR TITLE
subprocess_util: improve type hinting for CompletedProcess

### DIFF
--- a/src/antsibull_core/subprocess_util.py
+++ b/src/antsibull_core/subprocess_util.py
@@ -68,7 +68,7 @@ async def async_log_run(
     *,
     errors: str = 'strict',
     **kwargs,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """
     Asynchronously run a command in a subprocess and log its output.
     The command's stdout and stderr are always captured.
@@ -136,7 +136,7 @@ def log_run(
     stderr_loglevel: str | None = 'debug',
     check: bool = True,
     **kwargs,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """
     Synchronous wrapper for the async_log_run function.
     This function runs a command in a subprocess and captures and logs its

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -104,7 +104,7 @@ class VenvRunner:
         *,
         errors: str = 'strict',
         **kwargs,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         """
         This method asynchronously runs a command in a subprocess and logs
         its output. It calls `antsibull_core.subprocess_util.async_log_run` to
@@ -133,7 +133,7 @@ class VenvRunner:
         *,
         errors: str = 'strict',
         **kwargs,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         """
         See :method:`async_log_run`
         """


### PR DESCRIPTION
CompletedProcess is apparently a generic [1]. `stdout` and `stderr` are
always `str` in our implementation, so we should annotate them as such.

[1] https://github.com/python/typeshed/blob/7dcec5b3db887f518114486b3e4783dde244186d/stdlib/subprocess.pyi#L86
