### PR TITLE
Build compat release with ansible-core 2.14

### DIFF
--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -68,10 +68,10 @@ jobs:
           ./lint-pyre.sh
         working-directory: antsibull
 
-      - name: "Test building a release: Ansible 7 with ansible-core devel"
+      - name: "Test building a release: Ansible 7 with ansible-core 2.14"
         run: |
           . ./venv/bin/activate
-          ansible-playbook -vv playbooks/build-single-release.yaml -e antsibull_ansible_version=7.99.0 -e antsibull_build_file=ansible-7.build -e antsibull_data_dir="{{ antsibull_data_git_dir }}/7" -e antsibull_ansible_git_version=devel
+          ansible-playbook -vv playbooks/build-single-release.yaml -e antsibull_ansible_version=7.99.0 -e antsibull_build_file=ansible-7.build -e antsibull_data_dir="{{ antsibull_data_git_dir }}/7" -e antsibull_ansible_git_version=stable-2.14
         working-directory: antsibull
         env:
           # Make result better readable


### PR DESCRIPTION
Maybe this makes the failing CI go away (for now).

The error also happens in the antsibull repo, see https://github.com/ansible-community/antsibull/pull/511 to make it better readable.