### PR TITLE
FakeVenvRunner: replace python with sys.executable

### DIFF
--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -93,7 +93,7 @@ class VenvRunner:
             directly to :command:`pip install`.
         :returns: An :obj:`subprocess.CompletedProcess` for the pip output.
         """
-        return self.log_run(["pip", "install", package_name])  # pyre-ignore[6]
+        return self.log_run(['pip', 'install', package_name])  # pyre-ignore[6]
 
     async def async_log_run(
         self,
@@ -112,7 +112,7 @@ class VenvRunner:
         do the heavy lifting. `args[0]` must be a filename that's installed in
         the venv. If it's not, a `ValueError` will be raised.
         """
-        kwargs.setdefault("env", get_clean_environment())
+        kwargs.setdefault('env', get_clean_environment())
         basename = args[0]
         if os.path.isabs(basename):
             raise ValueError(f'{basename!r} must not be an absolute path!')

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -11,7 +11,7 @@ import asyncio
 import os
 import sys
 import venv
-from collections.abc import MutableSequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, NoReturn
 
 import sh
@@ -69,8 +69,7 @@ class VenvRunner:
         # we need pip19+ in order to work now.  RHEL8 and Ubuntu 18.04 contain a pip that's older
         # than that so we must upgrade to something even if it's not latest.
 
-        # pyre thinks a list is not a MutableSequence when it very much is.
-        self.log_run(['pip', 'install', '--upgrade', 'pip'])  # pyre-ignore[6]
+        self.log_run(['pip', 'install', '--upgrade', 'pip'])
 
     def get_command(self, executable_name) -> sh.Command:
         """
@@ -93,11 +92,11 @@ class VenvRunner:
             directly to :command:`pip install`.
         :returns: An :obj:`subprocess.CompletedProcess` for the pip output.
         """
-        return self.log_run(['pip', 'install', package_name])  # pyre-ignore[6]
+        return self.log_run(['pip', 'install', package_name])
 
     async def async_log_run(
         self,
-        args: MutableSequence[StrPath],
+        args: Sequence[StrPath],
         logger: TwiggyLogger | StdLogger | None = None,
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',
@@ -119,14 +118,14 @@ class VenvRunner:
         path = os.path.join(self.venv_dir, 'bin', basename)
         if not os.path.exists(path):
             raise ValueError(f'{path!r} does not exist!')
-        args[0] = path
+        args = [path, *args[1:]]
         return await subprocess_util.async_log_run(
             args, logger, stdout_loglevel, stderr_loglevel, check, errors=errors, **kwargs
         )
 
     def log_run(
         self,
-        args: MutableSequence[StrPath],
+        args: Sequence[StrPath],
         logger: TwiggyLogger | StdLogger | None = None,
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',
@@ -156,7 +155,7 @@ class FakeVenvRunner:
 
     @staticmethod
     async def async_log_run(
-        args: MutableSequence[StrPath],
+        args: Sequence[StrPath],
         logger: TwiggyLogger | StdLogger | None = None,
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',
@@ -172,7 +171,7 @@ class FakeVenvRunner:
         but 'python' will be replaced by `sys.executable`.
         """
         if args and args[0] == 'python':
-            args[0] = sys.executable
+            args = [sys.executable, *args[1:]]
         return await subprocess_util.async_log_run(
             args, logger, stdout_loglevel, stderr_loglevel, check, errors=errors, **kwargs
         )
@@ -180,7 +179,7 @@ class FakeVenvRunner:
     @classmethod
     def log_run(
         cls,
-        args: MutableSequence[StrPath],
+        args: Sequence[StrPath],
         logger: TwiggyLogger | StdLogger | None = None,
         stdout_loglevel: str | None = None,
         stderr_loglevel: str | None = 'debug',

--- a/tests/functional/test_venv.py
+++ b/tests/functional/test_venv.py
@@ -4,6 +4,7 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import os.path
+import sys
 from unittest import mock
 
 import pytest
@@ -47,3 +48,22 @@ def test_venv_log_run_error2(tmp_path):
     echo = '/usr/bin/echo'
     with pytest.raises(ValueError, match=rf'^{echo!r} must not be an absolute path!'):
         runner.log_run([echo, "This also won't work!"])
+
+
+def test_fake_venv_python():
+    with mock.patch.object(
+        subprocess_util, 'async_log_run', wraps=subprocess_util.async_log_run
+    ) as log_run:
+        args = ['python', '-c', 'import antsibull_core; print("Hello, world!")']
+        p = FakeVenvRunner.log_run(args)
+        assert p.stdout == 'Hello, world!\n'
+
+        args[0] = sys.executable
+        log_run.assert_called_once_with(
+            args,
+            None,
+            None,
+            'debug',
+            True,
+            errors='strict',
+        )

--- a/tests/functional/test_venv.py
+++ b/tests/functional/test_venv.py
@@ -58,6 +58,7 @@ def test_fake_venv_python():
         p = FakeVenvRunner.log_run(args)
         assert p.stdout == 'Hello, world!\n'
 
+        args = args.copy()
         args[0] = sys.executable
         log_run.assert_called_once_with(
             args,


### PR DESCRIPTION
This way you can run `venv.async_log_run()` and always get the correct
python. In VenvRunner, it be `{prefix}/bin/python`. Outside, it should
be `sys.executable`; the first python on $PATH may not be the one that
the program was executed with.
