### PR TITLE
remove improper usage of @cache on async functions

### DIFF
--- a/changelogs/fragments/67-cache.yaml
+++ b/changelogs/fragments/67-cache.yaml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - Remove improper usage of ``@functools.cache`` on async function in the
+  - Remove improper usage of ``@functools.cache`` on async functions in the
     ``antsibull_core.ansible_core`` module
     (https://github.com/ansible-community/antsibull-core/pull/67).

--- a/changelogs/fragments/67-cache.yaml
+++ b/changelogs/fragments/67-cache.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Remove improper usage of ``@functools.cache`` on async function in the
+    ``antsibull_core.ansible_core`` module
+    (https://github.com/ansible-community/antsibull-core/pull/67).

--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -14,7 +14,6 @@ import os
 import re
 import tempfile
 import typing as t
-from functools import cache
 from urllib.parse import urljoin
 
 import aiofiles
@@ -67,7 +66,6 @@ class AnsibleCorePyPiClient:
             pkg_info = await response.json()
         return pkg_info
 
-    @cache
     async def get_release_info(self) -> dict[str, t.Any]:
         """
         Retrieve information about releases of the ansible-core/ansible-base package from pypi.
@@ -243,7 +241,6 @@ def source_is_correct_version(ansible_core_source: str | None,
     return False
 
 
-@cache
 async def checkout_from_git(download_dir: str, repo_url: str = _ANSIBLE_CORE_URL) -> str:
     """
     Checkout the ansible-core git repo.
@@ -258,7 +255,6 @@ async def checkout_from_git(download_dir: str, repo_url: str = _ANSIBLE_CORE_URL
     return ansible_core_dir
 
 
-@cache
 async def create_sdist(source_dir: str, dest_dir: str) -> str:
     """
     Create an sdist for the python package at a given path.


### PR DESCRIPTION
Neither functools.cache nor functools.lru_cache which was previously
used here works properly with async functions. These decorators cache
the coroutine, but coroutines can only be awaited once, so this falls
apart.

Take the following example:

```
In [1]: from functools import cache

In [2]: @cache
   ...: async def abc():
   ...:     return 1234
   ...:

In [3]: print(await abc())
1234

In [4]: print(await abc())
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[4], line 1
----> 1 print(await abc())

RuntimeError: cannot reuse already awaited coroutine
```
