### PR TITLE
CI: remove in valid GHA parameters, make pyre work in CI

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-core
+          directory: antsibull-core

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,7 +93,8 @@ def codeqa(session: nox.Session):
 
 @nox.session
 def typing(session: nox.Session):
-    install(session, ".[typing]", editable=True)
+    # pyre does not work when we don't install ourself in editable mode 🙄.
+    install(session, "-e", ".[typing]")
     session.run("mypy", "src/antsibull_core")
 
     purelib = session.run(


### PR DESCRIPTION
- The `codecov/codecov-action` GHA action does not support a `working-directory` option, it's called `directory` instead.
- Pyre does not work when the project isn't installed in editable mode (https://github.com/ansible-community/antsibull-docs/pull/137).