### PR TITLE
Allow Galaxy downloader to trust collection cache

### DIFF
--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -23,6 +23,12 @@ file_check_content = 262144
 # to cache downloaded collection artefacts from Ansible Galaxy in that directory
 # and speed up the docs build time:
 #   collection_cache = ~/.cache/antsibull/collections
+# Uncomment the following to trust the collection cache. This means that ansible-core
+# will assume that if the collection cache contains an artifact, it is the current one
+# available on the Galaxy server. This avoids making a request to the Galaxy server to
+# figure out the artifact's checksum and comparting it before trusting the cached
+# artifact.
+#   trust_collection_cache = true
 logging_cfg = {
     version = 1.0
     outputs = {

--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -26,7 +26,7 @@ file_check_content = 262144
 # Uncomment the following to trust the collection cache. This means that antsibull-core
 # will assume that if the collection cache contains an artifact, it is the current one
 # available on the Galaxy server. This avoids making a request to the Galaxy server to
-# figure out the artifact's checksum and comparting it before trusting the cached
+# figure out the artifact's checksum and comparing it before trusting the cached
 # artifact.
 #   trust_collection_cache = true
 logging_cfg = {

--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -23,7 +23,7 @@ file_check_content = 262144
 # to cache downloaded collection artefacts from Ansible Galaxy in that directory
 # and speed up the docs build time:
 #   collection_cache = ~/.cache/antsibull/collections
-# Uncomment the following to trust the collection cache. This means that ansible-core
+# Uncomment the following to trust the collection cache. This means that antsibull-core
 # will assume that if the collection cache contains an artifact, it is the current one
 # available on the Galaxy server. This avoids making a request to the Galaxy server to
 # figure out the artifact's checksum and comparting it before trusting the cached

--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-ansible_base_url = https://github.com/ansible/ansible/
+ansible_core_repo_url = https://github.com/ansible/ansible/
 # Number of bytes to read or write at one time for network or file I/O:
 chunksize = 4096
 galaxy_url = https://galaxy.ansible.com/

--- a/changelogs/fragments/78-collection-cache.yml
+++ b/changelogs/fragments/78-collection-cache.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - "Avoid using the collection artifact filename returned by the Galaxy server. Instead compose it in a uniform way (https://github.com/ansible-community/antsibull-core/pull/78)."
+  - "Allow the Galaxy downloader to trust its collection cache to avoid having to query the Galaxy server if an artifact exists in the cache. This can be set with the new configuration file option ``trust_collection_cache`` (https://github.com/ansible-community/antsibull-core/pull/78)."

--- a/changelogs/fragments/78-collection-cache.yml
+++ b/changelogs/fragments/78-collection-cache.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - "Avoid using the collection artifact filename returned by the Galaxy server. Instead compose it in a uniform way (https://github.com/ansible-community/antsibull-core/pull/78)."
   - "Allow the Galaxy downloader to trust its collection cache to avoid having to query the Galaxy server if an artifact exists in the cache. This can be set with the new configuration file option ``trust_collection_cache`` (https://github.com/ansible-community/antsibull-core/pull/78)."
+  - "Allow to skip content check when doing async file copying using ``antsibull_core.utils.io.copy_file()`` (https://github.com/ansible-community/antsibull-core/pull/78)."

--- a/changelogs/fragments/78-collection-cache.yml
+++ b/changelogs/fragments/78-collection-cache.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Avoid using the collection artifact filename returned by the Galaxy server. Instead compose it in a uniform way (https://github.com/ansible-community/antsibull-core/pull/78)."

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -400,7 +400,7 @@ class CollectionDownloader(GalaxyClient):
             versions match the criteria (latest compatible version known to galaxy).
             Defaults to ``lib_ctx.get().collection_cache``.
         :kwarg trust_collection_cache: If set to ``True``, will assume that if the collection
-            cache contains an artifact, it is the latest one available on the Galaxy server.
+            cache contains an artifact, it is the current one available on the Galaxy server.
             This avoids making a request to the Galaxy server to figure out the artifact's
             checksum and comparting it before trusting the cached artifact.
         """

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -419,22 +419,18 @@ class CollectionDownloader(GalaxyClient):
         :arg version: Version of the collection to download.
         :returns: The full path to the downloaded collection.
         """
-        collection = collection.replace(".", "/")
-        release_info = await self.get_release_info(collection, version)
+        namespace, name = collection.split(".", 1)
+        filename = f"{namespace}-{name}-{version}.tar.gz"
+
+        release_info = await self.get_release_info(f"{namespace}/{name}", version)
         release_url = release_info["download_url"]
 
-        download_filename = os.path.join(
-            self.download_dir, release_info["artifact"]["filename"]
-        )
+        download_filename = os.path.join(self.download_dir, filename)
         sha256sum = release_info["artifact"]["sha256"]
 
         if self.collection_cache:
-            if release_info["artifact"]["filename"] in os.listdir(
-                self.collection_cache
-            ):
-                cached_copy = os.path.join(
-                    self.collection_cache, release_info["artifact"]["filename"]
-                )
+            if filename in os.listdir(self.collection_cache):
+                cached_copy = os.path.join(self.collection_cache, filename)
                 if await verify_hash(cached_copy, sha256sum):
                     shutil.copyfile(cached_copy, download_filename)
                     return download_filename
@@ -459,9 +455,7 @@ class CollectionDownloader(GalaxyClient):
 
         # Copy downloaded collection into cache
         if self.collection_cache:
-            cached_copy = os.path.join(
-                self.collection_cache, release_info["artifact"]["filename"]
-            )
+            cached_copy = os.path.join(self.collection_cache, filename)
             shutil.copyfile(download_filename, cached_copy)
 
         return download_filename

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -435,7 +435,7 @@ class CollectionDownloader(GalaxyClient):
         if self.collection_cache and self.trust_collection_cache:
             cached_copy = os.path.join(self.collection_cache, filename)
             if os.path.isfile(cached_copy):
-                await copy_file(cached_copy, download_filename)
+                await copy_file(cached_copy, download_filename, check_content=False)
                 return download_filename
 
         release_info = await self.get_release_info(f"{namespace}/{name}", version)
@@ -447,7 +447,7 @@ class CollectionDownloader(GalaxyClient):
             cached_copy = os.path.join(self.collection_cache, filename)
             if os.path.isfile(cached_copy):
                 if await verify_hash(cached_copy, sha256sum):
-                    await copy_file(cached_copy, download_filename)
+                    await copy_file(cached_copy, download_filename, check_content=False)
                     return download_filename
 
         async with retry_get(
@@ -471,7 +471,7 @@ class CollectionDownloader(GalaxyClient):
         # Copy downloaded collection into cache
         if self.collection_cache:
             cached_copy = os.path.join(self.collection_cache, filename)
-            await copy_file(download_filename, cached_copy)
+            await copy_file(download_filename, cached_copy, check_content=False)
 
         return download_filename
 

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import os.path
-import shutil
 import typing as t
 from enum import Enum
 from urllib.parse import urljoin
@@ -21,6 +20,7 @@ import semantic_version as semver
 from . import app_context
 from .utils.hashing import verify_hash
 from .utils.http import retry_get
+from .utils.io import copy_file
 
 # The type checker can handle finding aiohttp.client but flake8 cannot :-(
 if t.TYPE_CHECKING:
@@ -435,7 +435,7 @@ class CollectionDownloader(GalaxyClient):
         if self.collection_cache and self.trust_collection_cache:
             cached_copy = os.path.join(self.collection_cache, filename)
             if os.path.isfile(cached_copy):
-                shutil.copyfile(cached_copy, download_filename)
+                await copy_file(cached_copy, download_filename)
                 return download_filename
 
         release_info = await self.get_release_info(f"{namespace}/{name}", version)
@@ -447,7 +447,7 @@ class CollectionDownloader(GalaxyClient):
             cached_copy = os.path.join(self.collection_cache, filename)
             if os.path.isfile(cached_copy):
                 if await verify_hash(cached_copy, sha256sum):
-                    shutil.copyfile(cached_copy, download_filename)
+                    await copy_file(cached_copy, download_filename)
                     return download_filename
 
         async with retry_get(
@@ -471,7 +471,7 @@ class CollectionDownloader(GalaxyClient):
         # Copy downloaded collection into cache
         if self.collection_cache:
             cached_copy = os.path.join(self.collection_cache, filename)
-            shutil.copyfile(download_filename, cached_copy)
+            await copy_file(download_filename, cached_copy)
 
         return download_filename
 

--- a/src/antsibull_core/schemas/context.py
+++ b/src/antsibull_core/schemas/context.py
@@ -11,7 +11,7 @@ import pydantic as p
 
 from ..utils.collections import ContextDict
 from .config import DEFAULT_LOGGING_CONFIG, LoggingModel
-from .validators import convert_none, convert_path
+from .validators import convert_bool, convert_none, convert_path
 
 
 class BaseModel(p.BaseModel):
@@ -111,6 +111,10 @@ class LibContext(BaseModel):
     :ivar pypi_url: URL of the pypi server to query for information
     :ivar collection_cache: If set, must be a path pointing to a directory where collection
         tarballs are cached so they do not need to be downloaded from Galaxy twice.
+    :ivar trust_collection_cache: If set to ``True``, will assume that if the collection
+        cache contains an artifact, it is the latest one available on the Galaxy server.
+        This avoids making a request to the Galaxy server to figure out the artifact's
+        checksum and comparting it before trusting the cached artifact.
     """
 
     chunksize: int = 4096
@@ -131,6 +135,7 @@ class LibContext(BaseModel):
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = "https://pypi.org/"  # type: ignore[assignment]
     collection_cache: t.Optional[str] = None
+    trust_collection_cache: bool = False
 
     # pylint: disable-next=unused-private-member
     __convert_nones = p.validator("process_max", pre=True, allow_reuse=True)(
@@ -139,4 +144,8 @@ class LibContext(BaseModel):
     # pylint: disable-next=unused-private-member
     __convert_paths = p.validator("collection_cache", pre=True, allow_reuse=True)(
         convert_path
+    )
+    # pylint: disable-next=unused-private-member
+    __convert_bools = p.validator("trust_collection_cache", pre=True, allow_reuse=True)(
+        convert_bool
     )

--- a/src/antsibull_core/schemas/context.py
+++ b/src/antsibull_core/schemas/context.py
@@ -112,7 +112,7 @@ class LibContext(BaseModel):
     :ivar collection_cache: If set, must be a path pointing to a directory where collection
         tarballs are cached so they do not need to be downloaded from Galaxy twice.
     :ivar trust_collection_cache: If set to ``True``, will assume that if the collection
-        cache contains an artifact, it is the latest one available on the Galaxy server.
+        cache contains an artifact, it is the current one available on the Galaxy server.
         This avoids making a request to the Galaxy server to figure out the artifact's
         checksum and comparting it before trusting the cached artifact.
     """

--- a/src/antsibull_core/schemas/context.py
+++ b/src/antsibull_core/schemas/context.py
@@ -114,7 +114,7 @@ class LibContext(BaseModel):
     :ivar trust_collection_cache: If set to ``True``, will assume that if the collection
         cache contains an artifact, it is the current one available on the Galaxy server.
         This avoids making a request to the Galaxy server to figure out the artifact's
-        checksum and comparting it before trusting the cached artifact.
+        checksum and comparing it before trusting the cached artifact.
     """
 
     chunksize: int = 4096

--- a/src/antsibull_core/utils/io.py
+++ b/src/antsibull_core/utils/io.py
@@ -22,18 +22,22 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 
-async def copy_file(source_path: StrOrBytesPath, dest_path: StrOrBytesPath) -> None:
+async def copy_file(source_path: StrOrBytesPath, dest_path: StrOrBytesPath,
+                    check_content: bool = True) -> None:
     """
     Copy content from one file to another.
 
     :arg source_path: Source path. Must be a file.
     :arg dest_path: Destination path.
+    :kwarg check_content: If ``True`` (default) and ``lib_ctx.file_check_content > 0`` and the
+        destination file exists, first check whether source and destination are potentially equal
+        before actually copying,
     """
     flog = mlog.fields(func="copy_file")
     flog.debug("Enter")
 
     lib_ctx = app_context.lib_ctx.get()
-    if lib_ctx.file_check_content > 0:
+    if check_content and lib_ctx.file_check_content > 0:
         # Check whether the destination file exists and has the same content as the source file,
         # in which case we won't overwrite the destination file
         try:

--- a/src/antsibull_core/utils/io.py
+++ b/src/antsibull_core/utils/io.py
@@ -22,8 +22,9 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 
-async def copy_file(source_path: StrOrBytesPath, dest_path: StrOrBytesPath,
-                    check_content: bool = True) -> None:
+async def copy_file(
+    source_path: StrOrBytesPath, dest_path: StrOrBytesPath, check_content: bool = True
+) -> None:
     """
     Copy content from one file to another.
 


### PR DESCRIPTION
This allows to reduce the number of requests to the Galaxy server to zero when rebuilding Ansible (or a stable/devel docsite) when all required collection artifacts are already in the cache. Also the filename for the artifact is now determined by antsibull-core, and no longer by the Galaxy server.

Right now antsibull-core doesn't trust the cache and asks the Galaxy server for the filename and the SHA256 checksum of the artifact, and only then checks whether it has a file of that name in its cache, and whether the checksum matches. This means that even if the cache has been populated by the previous `antsibull-build prepare` call a few minutes ago, it has to query the Galaxy server again to make sure it has the latest versions. Especially since Community Galaxy does not allow the content of published collections to change, it is safe (especially for development purposes) to assume that the cache is trustworthy.