### PR TITLE
Add ansible-core cache

### DIFF
--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -29,6 +29,15 @@ file_check_content = 262144
 # figure out the artifact's checksum and comparing it before trusting the cached
 # artifact.
 #   trust_collection_cache = true
+# Uncomment the following after running `mkdir -p ~/.cache/antsibull/ansible-core`
+# to cache downloaded ansible-core artefacts from PyPI in that directory and speed up
+# the Ansible build time:
+#   ansible_core_cache = ~/.cache/antsibull/ansible-core
+# Uncomment the following to trust the ansible-core cache. This means that antsibull-core
+# will assume that if the ansible-core cache contains an artifact, it is the current one
+# available on PyPI. This avoids making a request to PyPI to figure out the artifact's
+# checksum and comparing it before trusting the cached artifact.
+#   trust_ansible_core_cache = true
 logging_cfg = {
     version = 1.0
     outputs = {

--- a/changelogs/fragments/80-ansible-core-cache.yml
+++ b/changelogs/fragments/80-ansible-core-cache.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Allow to cache ansible-core download artifacts with a new config file option ``ansible_core_cache`` (https://github.com/ansible-community/antsibull-core/pull/80)."
+  - "Allow to fully trust the ansible-core artifacts cache to avoid querying PyPI with a new config file option ``trust_ansible_core_cache`` (https://github.com/ansible-community/antsibull-core/pull/80)."

--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -85,9 +85,11 @@ class AnsibleCorePyPiClient:
         """
         # Retrieve the ansible-base and ansible-core package info from pypi
         tasks = []
-        for a_package_name in ("ansible-core", "ansible-base"):
-            if package_name is not None and a_package_name != package_name:
-                continue
+        for a_package_name in (
+            ("ansible-core", "ansible-base")
+            if package_name is None
+            else (package_name,)
+        ):
             query_url = urljoin(self.pypi_server_url, f"pypi/{a_package_name}/json")
             tasks.append(asyncio.create_task(self._get_json(query_url)))
 

--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -22,7 +22,9 @@ from packaging.version import Version as PypiVer
 from . import app_context
 from .logging import log
 from .subprocess_util import async_log_run
+from .utils.hashing import verify_a_hash
 from .utils.http import retry_get
+from .utils.io import copy_file
 
 if t.TYPE_CHECKING:
     import aiohttp.client
@@ -67,10 +69,13 @@ class AnsibleCorePyPiClient:
             pkg_info = await response.json()
         return pkg_info
 
-    async def get_release_info(self) -> dict[str, t.Any]:
+    async def get_release_info(
+        self, package_name: t.Optional[str] = None
+    ) -> dict[str, t.Any]:
         """
         Retrieve information about releases of the ansible-core/ansible-base package from pypi.
 
+        :arg package_name: Either 'ansible-core', 'ansible-base', or None.
         :returns: The dict which represents the release info keyed by version number.
             To examine the data structure, use::
 
@@ -80,14 +85,21 @@ class AnsibleCorePyPiClient:
         """
         # Retrieve the ansible-base and ansible-core package info from pypi
         tasks = []
-        for package_name in ("ansible-core", "ansible-base"):
-            query_url = urljoin(self.pypi_server_url, f"pypi/{package_name}/json")
+        for a_package_name in ("ansible-core", "ansible-base"):
+            if package_name is not None and a_package_name != package_name:
+                continue
+            query_url = urljoin(self.pypi_server_url, f"pypi/{a_package_name}/json")
             tasks.append(asyncio.create_task(self._get_json(query_url)))
 
         # Note: gather maintains the order of results
         results = await asyncio.gather(*tasks)
-        release_info = results[1]["releases"]  # ansible-base information
-        release_info.update(results[0]["releases"])  # ansible-core information
+        if len(results) > 1:
+            release_info = results[1]["releases"]  # ansible-base information
+            release_info.update(results[0]["releases"])  # ansible-core information
+        elif len(results) == 1:
+            release_info = results[0]["releases"]
+        else:
+            release_info = {}
 
         return release_info
 
@@ -128,15 +140,26 @@ class AnsibleCorePyPiClient:
         :returns: The name of the downloaded tarball.
         """
         package_name = get_ansible_core_package_name(ansible_core_version)
-        release_info = await self.get_release_info()
+        release_info = await self.get_release_info(package_name)
 
-        pypi_url = tar_filename = ""
+        tar_filename = f"{package_name}-{ansible_core_version}.tar.gz"
+        tar_path = os.path.join(download_dir, tar_filename)
+
+        lib_ctx = app_context.lib_ctx.get()
+        if lib_ctx.ansible_core_cache and lib_ctx.trust_ansible_core_cache:
+            cached_path = os.path.join(lib_ctx.ansible_core_cache, tar_filename)
+            if os.path.isfile(cached_path):
+                await copy_file(cached_path, tar_path, check_content=False)
+                return tar_path
+
+        pypi_url = ""
+        digests = {}
         for release in release_info[ansible_core_version]:
             if release["filename"].startswith(
                 f"{package_name}-{ansible_core_version}.tar."
             ):
-                tar_filename = release["filename"]
                 pypi_url = release["url"]
+                digests = release["digests"]
                 break
         else:  # for-else: http://bit.ly/1ElPkyg
             raise UnknownVersion(
@@ -144,14 +167,23 @@ class AnsibleCorePyPiClient:
                 " exist on {self.pypi_server_url}"
             )
 
-        tar_filename = os.path.join(download_dir, tar_filename)
+        if lib_ctx.ansible_core_cache and "sha256" in digests:
+            cached_path = os.path.join(lib_ctx.ansible_core_cache, tar_filename)
+            if os.path.isfile(cached_path):
+                if await verify_a_hash(cached_path, digests):
+                    await copy_file(cached_path, tar_path, check_content=False)
+                    return tar_path
+
         async with retry_get(self.aio_session, pypi_url) as response:
-            async with aiofiles.open(tar_filename, "wb") as f:
-                lib_ctx = app_context.lib_ctx.get()
+            async with aiofiles.open(tar_path, "wb") as f:
                 while chunk := await response.content.read(lib_ctx.chunksize):
                     await f.write(chunk)
 
-        return tar_filename
+        if lib_ctx.ansible_core_cache:
+            cached_path = os.path.join(lib_ctx.ansible_core_cache, tar_filename)
+            await copy_file(tar_path, cached_path, check_content=False)
+
+        return tar_path
 
 
 def get_ansible_core_package_name(ansible_core_version: str | PypiVer) -> str:

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -402,7 +402,7 @@ class CollectionDownloader(GalaxyClient):
         :kwarg trust_collection_cache: If set to ``True``, will assume that if the collection
             cache contains an artifact, it is the current one available on the Galaxy server.
             This avoids making a request to the Galaxy server to figure out the artifact's
-            checksum and comparting it before trusting the cached artifact.
+            checksum and comparing it before trusting the cached artifact.
         """
         super().__init__(aio_session, galaxy_server=galaxy_server, context=context)
         self.download_dir = download_dir

--- a/src/antsibull_core/schemas/context.py
+++ b/src/antsibull_core/schemas/context.py
@@ -115,6 +115,12 @@ class LibContext(BaseModel):
         cache contains an artifact, it is the current one available on the Galaxy server.
         This avoids making a request to the Galaxy server to figure out the artifact's
         checksum and comparing it before trusting the cached artifact.
+    :ivar ansible_core_cache: If set, must be a path pointing to a directory where ansible-core
+        tarballs are cached so they do not need to be downloaded from PyPI twice.
+    :ivar trust_ansible_core_cache: If set to ``True``, will assume that if the ansible-core
+        cache contains an artifact, it is the current one available on PyPI. This avoids making a
+        request to PyPI to figure out the artifact's checksum and comparing it before trusting
+        the cached artifact.
     """
 
     chunksize: int = 4096
@@ -136,16 +142,18 @@ class LibContext(BaseModel):
     pypi_url: p.HttpUrl = "https://pypi.org/"  # type: ignore[assignment]
     collection_cache: t.Optional[str] = None
     trust_collection_cache: bool = False
+    ansible_core_cache: t.Optional[str] = None
+    trust_ansible_core_cache: bool = False
 
     # pylint: disable-next=unused-private-member
     __convert_nones = p.validator("process_max", pre=True, allow_reuse=True)(
         convert_none
     )
     # pylint: disable-next=unused-private-member
-    __convert_paths = p.validator("collection_cache", pre=True, allow_reuse=True)(
-        convert_path
-    )
+    __convert_paths = p.validator(
+        "ansible_core_cache", "collection_cache", pre=True, allow_reuse=True
+    )(convert_path)
     # pylint: disable-next=unused-private-member
-    __convert_bools = p.validator("trust_collection_cache", pre=True, allow_reuse=True)(
-        convert_bool
-    )
+    __convert_bools = p.validator(
+        "trust_ansible_core_cache", "trust_collection_cache", pre=True, allow_reuse=True
+    )(convert_bool)

--- a/src/antsibull_core/utils/hashing.py
+++ b/src/antsibull_core/utils/hashing.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import hashlib
+import typing as t
 from collections.abc import Mapping
 
 import aiofiles
@@ -15,8 +16,24 @@ import aiofiles
 from .. import app_context
 
 
+class _AlgorithmData(t.NamedTuple):
+    name: str
+    algorithm: str
+    kwargs: dict
+
+
+_PREFERRED_HASHES = [
+    # https://pypi.org/help/#verify-hashes, https://github.com/pypi/warehouse/issues/9628
+    _AlgorithmData("sha256", "sha256", {}),
+    _AlgorithmData("blake2b_256", "blake2b", {'digest_size': 32}),
+]
+
+
 async def verify_hash(
-    filename: str, hash_digest: str, algorithm: str = "sha256"
+    filename: str,
+    hash_digest: str,
+    algorithm: str = "sha256",
+    algorithm_kwargs: dict | None = None,
 ) -> bool:
     """
     Verify whether a file has a given sha256sum.
@@ -25,9 +42,10 @@ async def verify_hash(
     :arg hash_digest: The hash that is expected.
     :kwarg algorithm: The hash algorithm to use.  This must be present in hashlib on this
         system.  The default is 'sha256'
+    :kwarg algorithm_kwargs: Parameters to provide to the hash algorithm's constructor.
     :returns: True if the hash matches, otherwise False.
     """
-    hasher = getattr(hashlib, algorithm)()
+    hasher = getattr(hashlib, algorithm)(**(algorithm_kwargs or {}))
     async with aiofiles.open(filename, "rb") as f:
         ctx = app_context.lib_ctx.get()
         while chunk := await f.read(ctx.chunksize):
@@ -47,9 +65,12 @@ async def verify_a_hash(filename: str, hash_digests: Mapping[str, str]) -> bool:
     :arg hash_digest: A mapping of hash types to digests.
     :returns: True if the hash matches, otherwise False.
     """
-    for algorithm in ("sha256", "blake2b_256"):
-        if algorithm in hash_digests:
+    for algorithm_data in _PREFERRED_HASHES:
+        if algorithm_data.name in hash_digests:
             return await verify_hash(
-                filename, hash_digests[algorithm], algorithm=algorithm
+                filename,
+                hash_digests[algorithm_data.name],
+                algorithm=algorithm_data.algorithm,
+                algorithm_kwargs=algorithm_data.kwargs,
             )
     return False

--- a/src/antsibull_core/utils/hashing.py
+++ b/src/antsibull_core/utils/hashing.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import typing as t
 from collections.abc import Mapping
@@ -16,24 +17,25 @@ import aiofiles
 from .. import app_context
 
 
-class _AlgorithmData(t.NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class _AlgorithmData:
     name: str
     algorithm: str
-    kwargs: dict
+    kwargs: dict[str, t.Any]
 
 
-_PREFERRED_HASHES = [
+_PREFERRED_HASHES: tuple[_AlgorithmData, ...] = (
     # https://pypi.org/help/#verify-hashes, https://github.com/pypi/warehouse/issues/9628
-    _AlgorithmData("sha256", "sha256", {}),
-    _AlgorithmData("blake2b_256", "blake2b", {"digest_size": 32}),
-]
+    _AlgorithmData(name="sha256", algorithm="sha256", kwargs={}),
+    _AlgorithmData(name="blake2b_256", algorithm="blake2b", kwargs={"digest_size": 32}),
+)
 
 
 async def verify_hash(
     filename: str,
     hash_digest: str,
     algorithm: str = "sha256",
-    algorithm_kwargs: dict | None = None,
+    algorithm_kwargs: dict[str, t.Any] | None = None,
 ) -> bool:
     """
     Verify whether a file has a given sha256sum.

--- a/src/antsibull_core/utils/hashing.py
+++ b/src/antsibull_core/utils/hashing.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 
 import aiofiles
 
@@ -35,3 +36,20 @@ async def verify_hash(
         return False
 
     return True
+
+
+async def verify_a_hash(filename: str, hash_digests: Mapping[str, str]) -> bool:
+    """
+    Verify whether a file has a given hash, given a set of digests with different algorithms.
+    Will only test trustworthy hashes and return ``False`` if none matches.
+
+    :arg filename: The file to verify the hash of.
+    :arg hash_digest: A mapping of hash types to digests.
+    :returns: True if the hash matches, otherwise False.
+    """
+    for algorithm in ("sha256", "blake2b_256"):
+        if algorithm in hash_digests:
+            return await verify_hash(
+                filename, hash_digests[algorithm], algorithm=algorithm
+            )
+    return False

--- a/src/antsibull_core/utils/hashing.py
+++ b/src/antsibull_core/utils/hashing.py
@@ -25,7 +25,7 @@ class _AlgorithmData(t.NamedTuple):
 _PREFERRED_HASHES = [
     # https://pypi.org/help/#verify-hashes, https://github.com/pypi/warehouse/issues/9628
     _AlgorithmData("sha256", "sha256", {}),
-    _AlgorithmData("blake2b_256", "blake2b", {'digest_size': 32}),
+    _AlgorithmData("blake2b_256", "blake2b", {"digest_size": 32}),
 ]
 
 

--- a/tests/units/test_utils_hashing.py
+++ b/tests/units/test_utils_hashing.py
@@ -1,0 +1,103 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project
+
+from __future__ import annotations
+
+import pytest
+
+from antsibull_core.utils.hashing import verify_a_hash, verify_hash
+
+HASH_TESTS = [
+    (
+        b"",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256",
+        {},
+        True,
+    ),
+    (
+        b"",
+        "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+        "sha256",
+        {},
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "content, hash, algorithm, algorithm_kwargs, expected_match", HASH_TESTS
+)
+@pytest.mark.asyncio
+async def test_verify_hash(
+    content: bytes,
+    hash: bytes,
+    algorithm: str,
+    algorithm_kwargs: dict | None,
+    expected_match: bool,
+    tmp_path,
+):
+    filename = tmp_path / "file"
+    with open(filename, "wb") as f:
+        f.write(content)
+    result = await verify_hash(
+        filename, hash, algorithm=algorithm, algorithm_kwargs=algorithm_kwargs
+    )
+    assert result is expected_match
+
+
+HASH_DICT_TESTS = [
+    (
+        b"foo",
+        {
+            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+        },
+        True,
+    ),
+    (
+        b"bar",
+        {
+            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+        },
+        False,
+    ),
+    (
+        b"foo",
+        {
+            "blake2b_256": "b8fe9f7f6255a6fa08f668ab632a8d081ad87983c77cd274e48ce450f0b349fd",
+        },
+        True,
+    ),
+    (
+        b"bar",
+        {
+            "blake2b_256": "b8fe9f7f6255a6fa08f668ab632a8d081ad87983c77cd274e48ce450f0b349fd",
+        },
+        False,
+    ),
+    (
+        b"",
+        {},
+        False,
+    ),
+    (
+        b"",
+        {
+            "foo": "bar",
+        },
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("content, hash_digests, expected_match", HASH_DICT_TESTS)
+@pytest.mark.asyncio
+async def test_verify_a_hash(
+    content: bytes, hash_digests: dict[str, str], expected_match: bool, tmp_path
+):
+    filename = tmp_path / "file"
+    with open(filename, "wb") as f:
+        f.write(content)
+    result = await verify_a_hash(filename, hash_digests)
+    assert result is expected_match


### PR DESCRIPTION
Add config file options `ansible_core_cache` and `trust_ansible_core_cache` (the latter similar to #78) to the library context to allow caching (and trusting the cache) ansible-base and ansible-core release artifacts.

(I'm not able to test this without trusting the cache right now, so marking it as a draft.)