### PR TITLE
Clean up configuration

### DIFF
--- a/changelogs/fragments/82-config-model.yml
+++ b/changelogs/fragments/82-config-model.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - "The unused ``antsibull_core.schemas.config.ConfigModel`` model and the unused ``antsibull_core.config.read_config`` function have been removed (https://github.com/ansible-community/antsibull-core/pull/82)."

--- a/src/antsibull_core/config.py
+++ b/src/antsibull_core/config.py
@@ -14,7 +14,6 @@ import perky  # type: ignore[import]
 import pydantic as p
 
 from .logging import log
-from .schemas.config import ConfigModel
 from .schemas.context import AppContext, LibContext
 
 mlog = log.fields(mod=__name__)
@@ -51,29 +50,6 @@ def find_config_files(conf_files: Iterable[str]) -> list[str]:
 
     flog.debug("Leave")
     return config_files
-
-
-def read_config(filename: str) -> ConfigModel:
-    """
-    Parse a config file and return the data from it.
-
-    :arg filename: The filename of the config file to parse.
-    :returns: A ConfigModel model containing the config data.
-    """
-    flog = mlog.fields(func="read_config")
-    flog.debug("Enter")
-
-    filename = os.path.abspath(filename)
-
-    flog.fields(filename=filename).info("loading config file")
-    raw_config_data = perky.load(filename)
-    flog.debug("Validatinging the config file data")
-    # Note: We parse the object but discard the model because we want to validate the config but let
-    # the context handle all setting of defaults
-    ConfigModel.parse_obj(raw_config_data)
-
-    flog.debug("Leave")
-    return raw_config_data
 
 
 def validate_config(

--- a/src/antsibull_core/schemas/config.py
+++ b/src/antsibull_core/schemas/config.py
@@ -3,7 +3,7 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2021, Ansible Project
-"""Schemas for config files."""
+"""Schemas for logging config."""
 
 import os.path
 import typing as t
@@ -13,16 +13,9 @@ import pydantic as p
 import twiggy.formats  # type: ignore[import]
 import twiggy.outputs  # type: ignore[import]
 
-from .validators import convert_none, convert_path
-
 #: Valid choices for a logging level field
 LEVEL_CHOICES_F = p.Field(
     ..., regex="^(CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG|DISABLED)$"
-)
-
-#: Valid choices for a logging level field
-_DOC_PARSING_BACKEND_CHOICES_F = p.Field(
-    "ansible-internal", regex="^(auto|ansible-doc|ansible-core-2.13|ansible-internal)$"
 )
 
 #: Valid choice of the logging version field
@@ -112,29 +105,3 @@ DEFAULT_LOGGING_CONFIG = LoggingModel.parse_obj(
         },
     }
 )
-
-
-# This class is no longer needed, it will eventually be removed
-class ConfigModel(BaseModel):
-    # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
-    ansible_base_url: p.HttpUrl = "https://github.com/ansible/ansible"  # type: ignore[assignment]
-    chunksize: int = 4096
-    # DEPRECATED: doc_parsing_backend will be removed in antsibull-core 3.0.0
-    doc_parsing_backend: str = _DOC_PARSING_BACKEND_CHOICES_F
-    # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
-    galaxy_url: p.HttpUrl = "https://galaxy.ansible.com/"  # type: ignore[assignment]
-    logging_cfg: LoggingModel = DEFAULT_LOGGING_CONFIG
-    max_retries: int = 10
-    process_max: t.Optional[int] = None
-    # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
-    pypi_url: p.HttpUrl = "https://pypi.org/"  # type: ignore[assignment]
-    thread_max: int = 8
-    file_check_content: int = 262144
-    collection_cache: t.Optional[str] = None
-
-    _convert_nones = p.validator("process_max", pre=True, allow_reuse=True)(
-        convert_none
-    )
-    _convert_paths = p.validator("collection_cache", pre=True, allow_reuse=True)(
-        convert_path
-    )


### PR DESCRIPTION
Revival of #79 that should actually work. The `ConfigModel` there was used in `read_config()`, which turned out to not be used anywhere. Also `read_config()` claimed to return a `ConfigModel` instance, while it actually returned a `Mapping`.

I decided to delete that function as well since fixing it would be more complicated, and it's not really needed anyway since config file loading is handled better by other functions in that module.