### PR TITLE
Enable version list test for Galaxy v3 API

### DIFF
--- a/tests/functional/test_galaxy.py
+++ b/tests/functional/test_galaxy.py
@@ -213,6 +213,4 @@ async def test_galaxy_v3(tmp_path_factory):
         context = await GalaxyContext.create(aio_session, galaxy_url)
         assert context.version == GalaxyVersion.V3
         assert context.base_url == galaxy_url + "/api/v3/"
-        await galaxy_client_test(
-            aio_session, context, tmp_path_factory, skip_versions_test=True
-        )
+        await galaxy_client_test(aio_session, context, tmp_path_factory)


### PR DESCRIPTION
beta-galaxy got a **lot** faster. Potentially due to https://github.com/pulp/pulp_ansible/pull/1408.