### PR TITLE
[stable-1] test_galaxy: use old-galaxy for v2 API tests

### DIFF
--- a/tests/functional/test_galaxy.py
+++ b/tests/functional/test_galaxy.py
@@ -86,7 +86,7 @@ async def galaxy_client_test(aio_session: aiohttp.ClientSession, context: Galaxy
 
 @pytest.mark.asyncio
 async def test_galaxy_v2(tmp_path_factory):
-    galaxy_url = 'https://galaxy.ansible.com'
+    galaxy_url = 'https://old-galaxy.ansible.com'
     async with aiohttp.ClientSession() as aio_session:
         context = await GalaxyContext.create(aio_session, galaxy_url)
         assert context.version == GalaxyVersion.V2
@@ -96,7 +96,7 @@ async def test_galaxy_v2(tmp_path_factory):
 
 @pytest.mark.asyncio
 async def test_galaxy_v3(tmp_path_factory):
-    galaxy_url = 'https://beta-galaxy.ansible.com'
+    galaxy_url = 'https://galaxy.ansible.com'
     async with aiohttp.ClientSession() as aio_session:
         context = await GalaxyContext.create(aio_session, galaxy_url)
         assert context.version == GalaxyVersion.V3


### PR DESCRIPTION
galaxy.ansible.com was officially switched over to the Galaxy NG
codebase which only supports the v3 API.
For now, we can test the v2 api against old-galaxy.ansible.com.

(cherry picked from commit 1eac01034da9643f517069e5a1a19f78a64c9ae7)

---

`main` used double quotes and `stable-1` used single quotes,
so I did a manual backport to resolve the conflict.
