### PR TITLE
Fix typing for app_context

### DIFF
--- a/changelogs/fragments/109-typing.yml
+++ b/changelogs/fragments/109-typing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix typing for ``antsibull_core.app_context.app_context()`` functions (https://github.com/ansible-community/antsibull-core/pull/109)."

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -107,7 +107,7 @@ import argparse
 import contextvars
 import typing as t
 from collections.abc import Iterable, Mapping
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 
 from .schemas.context import AppContext, LibContext
 from .vendored.collections import ImmutableDict
@@ -368,14 +368,12 @@ def lib_context(
 
 
 @t.overload
-@contextmanager
-def app_context() -> t.ContextManager[AppContext]:
+def app_context() -> AbstractContextManager[AppContext]:
     ...
 
 
 @t.overload
-@contextmanager
-def app_context(new_context: AppContextT) -> t.ContextManager[AppContextT]:
+def app_context(new_context: AppContextT) -> AbstractContextManager[AppContextT]:
     ...
 
 


### PR DESCRIPTION
Currently the typing checks fail on `main` (see for example https://github.com/ansible-community/antsibull-core/actions/runs/6478324868/job/17589911927?pr=105). (Having `@contextmanager` in the overloads transforms the typing of the function stub. Also `typing.ContextManager` is a deprecated alias for `contextlib.AbstractContextManager`.)