### PR TITLE
Use Sequence[] instead of list[] for lists of StrPath

### DIFF
--- a/src/antsibull_core/collections.py
+++ b/src/antsibull_core/collections.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 import typing as t
+from collections.abc import Sequence
 
 from .subprocess_util import async_log_run
 
@@ -22,7 +23,7 @@ class CollectionFormatError(Exception):
 
 
 async def install_together(
-    collection_tarballs: list[StrPath], ansible_collections_dir: StrPath
+    collection_tarballs: Sequence[StrPath], ansible_collections_dir: StrPath
 ) -> None:
     installers = []
     for pathname in collection_tarballs:
@@ -44,7 +45,7 @@ async def install_together(
 
 
 async def install_separately(
-    collection_tarballs: list[StrPath], collection_dir: StrPath
+    collection_tarballs: Sequence[StrPath], collection_dir: StrPath
 ) -> list[str]:
     installers = []
     collection_dirs: list[str] = []

--- a/src/antsibull_core/config.py
+++ b/src/antsibull_core/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os.path
 import typing as t
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 
 import perky  # type: ignore[import]
 import pydantic as p
@@ -61,7 +61,7 @@ def find_config_files(conf_files: Iterable[StrPath]) -> list[str]:
 
 def validate_config(
     config: Mapping,
-    filenames: list[StrPath] | list[str],
+    filenames: Sequence[StrPath],
     app_context_model: type[AppContext],
 ) -> None:
     """


### PR DESCRIPTION
Follow-up to #105, which broke type checks for antsibull:
```
src/antsibull/build_ansible_commands.py:656: error: Argument 1 to "install_together" has incompatible type "list[str]"; expected "list[str | PathLike[str]]"  [arg-type]
src/antsibull/build_ansible_commands.py:656: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
src/antsibull/build_ansible_commands.py:656: note: Consider using "Sequence" instead, which is covariant
```
(https://github.com/ansible-community/antsibull/actions/runs/6766190684/job/18386917570)