### PR TITLE
Revert "nox: temporarily set AIOHTTP_NO_EXTENSIONS for 3.12"

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,10 +30,6 @@ def install(session: nox.Session, *args, editable=False, **kwargs):
     # This ensures that the wheel contains all of the correct files.
     if editable and ALLOW_EDITABLE:
         args = ("-e", *args)
-    # TODO: Remove this once aiohttp's extension module supports Python 3.12
-    if session.python == "3.12":
-        kwargs.setdefault("env", {})["AIOHTTP_NO_EXTENSIONS"] = "1"
-
     session.install(*args, "-U", **kwargs)
 
 


### PR DESCRIPTION
aiohttp now natively supports Python 3.12.
