### PR TITLE
store package version in __version__ constant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "antsibull-core"
-version = "2.1.0.post0"
+dynamic = [
+    "version",
+]
 description = "Tools for building the Ansible Distribution"
 license = "GPL-3.0-or-later AND BSD-2-Clause AND MIT AND PSF-2.0"
 license-files = {globs=["LICENSES/*.txt"]}
@@ -105,6 +107,9 @@ dev = [
     "nox",
 
 ]
+
+[tool.hatch.version]
+path = "src/antsibull_core/__init__.py"
 
 [tool.isort]
 profile = "black"

--- a/src/antsibull_core/__init__.py
+++ b/src/antsibull_core/__init__.py
@@ -2,3 +2,13 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
+
+"""
+Shared code used by tools for building the Ansible distribution
+"""
+
+from __future__ import annotations
+
+__version__ = "2.1.0.post0"
+
+__all__ = ("__version__",)


### PR DESCRIPTION
This allows using the `hatch version` tool to automatically update
versions and makes sure the version metadata of editable installs is
always up to date.
