### PR TITLE
add pydantic v2 support and drop v1

### DIFF
--- a/changelogs/fragments/122-pydanticv2.yaml
+++ b/changelogs/fragments/122-pydanticv2.yaml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - "antsibull-core now requires major version 2 of the ``pydantic`` library.
+    Version 1 is no longer supported
+    (https://github.com/ansible-community/antsibull-core/pull/122)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "packaging >= 20.0",
     "perky",
     # pydantic v2 is a major rewrite
-    "pydantic >= 1.0.0, < 2.0.0",
+    "pydantic ~= 2.0",
     "PyYAML",
     "semantic_version",
     # 0.5.0 introduces dict_config

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -280,8 +280,8 @@ def create_contexts(
         If the field is only used via the :attr:`AppContext.extra` mechanism (not explictly set),
         then you should ignore this section and use :python:mod:`argparse`'s default mechanism.
     """
-    fields_in_lib_ctx = set(LibContext.__fields__)
-    fields_in_app_ctx = set(app_context_model.__fields__)
+    fields_in_lib_ctx = set(LibContext.model_fields)
+    fields_in_app_ctx = set(app_context_model.model_fields)
     known_fields = fields_in_app_ctx.union(fields_in_lib_ctx)
 
     normalized_cfg = dict(cfg)
@@ -335,7 +335,7 @@ def _copy_lib_context() -> LibContext:
         old_context = LibContext()
 
     # Copy just in case contexts are allowed to be writable in the the future
-    return old_context.copy()
+    return old_context.model_copy()
 
 
 def _copy_app_context() -> AppContext:
@@ -345,7 +345,7 @@ def _copy_app_context() -> AppContext:
         old_context = AppContext()
 
     # Copy just in case contexts are allowed to be writable in the the future
-    return old_context.copy()
+    return old_context.model_copy()
 
 
 @contextmanager

--- a/src/antsibull_core/config.py
+++ b/src/antsibull_core/config.py
@@ -71,7 +71,7 @@ def validate_config(
     splits up the config into lib context and app context part and validates both parts with the
     given model. Raises a :obj:`ConfigError` if validation fails.
     """
-    lib_fields = set(LibContext.__fields__)
+    lib_fields = set(LibContext.model_fields)
     lib = {}
     app = {}
     for key, value in config.items():
@@ -82,8 +82,8 @@ def validate_config(
     # Note: We parse the object but discard the model because we want to validate the config but let
     # the context handle all setting of defaults
     try:
-        LibContext.parse_obj(lib)
-        app_context_model.parse_obj(app)
+        LibContext.model_validate(lib)
+        app_context_model.model_validate(app)
     except p.ValidationError as exc:
         joined_filenames = ", ".join(f"{fn}" for fn in filenames)
         raise ConfigError(

--- a/src/antsibull_core/galaxy.py
+++ b/src/antsibull_core/galaxy.py
@@ -73,7 +73,7 @@ class GalaxyContext:
         :kwarg galaxy_server: A Galaxy server URL. Defaults to ``lib_ctx.get().galaxy_server``.
         """
         if galaxy_server is None:
-            galaxy_server = app_context.lib_ctx.get().galaxy_url
+            galaxy_server = str(app_context.lib_ctx.get().galaxy_url)
         api_url = urljoin(galaxy_server, "api/")
         async with retry_get(
             aio_session, api_url, headers={"Accept": "application/json"}
@@ -144,7 +144,7 @@ class GalaxyClient:
         """
         if galaxy_server is None and context is None:
             # TODO: deprecate
-            galaxy_server = app_context.lib_ctx.get().galaxy_url
+            galaxy_server = str(app_context.lib_ctx.get().galaxy_url)
         elif context is not None:
             # TODO: deprecate
             if galaxy_server is not None and galaxy_server != context.server:

--- a/src/antsibull_core/utils/collections.py
+++ b/src/antsibull_core/utils/collections.py
@@ -124,10 +124,6 @@ class ContextDict(ImmutableDict):
         super().__init__(toplevel)
 
     @classmethod
-    def __get_validators__(cls):
-        yield cls.validate_and_convert
-
-    @classmethod
     def validate_and_convert(cls, value: Mapping) -> "ContextDict":
         if isinstance(value, ContextDict):
             # optimization.  If it's already an ImmutableContext, we don't need to recursively

--- a/tests/units/test_context.py
+++ b/tests/units/test_context.py
@@ -4,6 +4,8 @@
 
 import argparse
 
+from pydantic import HttpUrl
+
 import antsibull_core.app_context as ap
 from antsibull_core.schemas.config import LoggingModel
 from antsibull_core.utils.collections import ContextDict
@@ -23,9 +25,9 @@ def test_default():
 
     app_ctx = ap.app_ctx.get()
     assert app_ctx.extra == ContextDict()
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://pypi.org/")
 
 
 def test_create_contexts_with_cfg():
@@ -42,9 +44,9 @@ def test_create_contexts_with_cfg():
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict({"unknown": True})
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://test.pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://test.pypi.org/")
 
 
 def test_create_contexts_with_args():
@@ -62,9 +64,9 @@ def test_create_contexts_with_args():
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict({"unknown": True})
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://test.pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://test.pypi.org/")
 
 
 def test_create_contexts_with_args_and_cfg():
@@ -95,9 +97,9 @@ def test_create_contexts_with_args_and_cfg():
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict({"unknown": False, "cfg": 1, "args": 2})
-    assert app_ctx.galaxy_url == "https://dev.galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://dev.galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://other.pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://other.pypi.org/")
 
 
 def test_create_contexts_without_extra():
@@ -118,9 +120,9 @@ def test_create_contexts_without_extra():
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict()
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://pypi.org/")
 
 
 #
@@ -135,11 +137,11 @@ def test_context_overrides():
 
     with ap.app_context(data.app_ctx) as app_ctx:
         # Test that the app_context that was returned has the new values
-        assert app_ctx.galaxy_url == "https://dev.galaxy.ansible.com/"
+        assert app_ctx.galaxy_url == HttpUrl("https://dev.galaxy.ansible.com/")
 
         # Test that the context that we can retrieve has the new values too
         app_ctx = ap.app_ctx.get()
-        assert app_ctx.galaxy_url == "https://dev.galaxy.ansible.com/"
+        assert app_ctx.galaxy_url == HttpUrl("https://dev.galaxy.ansible.com/")
 
     with ap.lib_context(data.lib_ctx) as lib_ctx:
         # Test that the returned lib_ctx has the new values
@@ -152,9 +154,9 @@ def test_context_overrides():
     # Check that once we return from the context managers, the old values have been restored
     app_ctx = ap.app_ctx.get()
     assert app_ctx.extra == ContextDict()
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://pypi.org/")
 
     lib_ctx = ap.lib_ctx.get()
     assert lib_ctx.chunksize == 4096
@@ -200,11 +202,11 @@ def test_app_and_lib_context():
 
     with ap.app_and_lib_context(data) as (app_ctx, lib_ctx):
         # Test that the app_context that was returned has the new values
-        assert app_ctx.galaxy_url == "https://dev.galaxy.ansible.com/"
+        assert app_ctx.galaxy_url == HttpUrl("https://dev.galaxy.ansible.com/")
 
         # Test that the context that we can retrieve has the new values too
         app_ctx = ap.app_ctx.get()
-        assert app_ctx.galaxy_url == "https://dev.galaxy.ansible.com/"
+        assert app_ctx.galaxy_url == HttpUrl("https://dev.galaxy.ansible.com/")
 
         # Test that the returned lib_ctx has the new values
         assert lib_ctx.chunksize == 5
@@ -216,9 +218,9 @@ def test_app_and_lib_context():
     # Check that once we return from the context manager, the old values have been restored
     app_ctx = ap.app_ctx.get()
     assert app_ctx.extra == ContextDict()
-    assert app_ctx.galaxy_url == "https://galaxy.ansible.com/"
+    assert app_ctx.galaxy_url == HttpUrl("https://galaxy.ansible.com/")
     assert isinstance(app_ctx.logging_cfg, LoggingModel)
-    assert app_ctx.pypi_url == "https://pypi.org/"
+    assert app_ctx.pypi_url == HttpUrl("https://pypi.org/")
 
     lib_ctx = ap.lib_ctx.get()
     assert lib_ctx.chunksize == 4096


### PR DESCRIPTION
pydantic v2 has a fair amount of API changes and deprecations that make simultaneously supporting it and v1 impractical. antsibull, antsibull-docs, and other dependent packages will require some small changes, as well.

---

Fixes: https://github.com/ansible-community/antsibull-core/issues/92