### PR TITLE
deprecate support for old ansible versions <6.0.0

### DIFF
--- a/changelogs/fragments/130-old-ansible-dep.yaml
+++ b/changelogs/fragments/130-old-ansible-dep.yaml
@@ -1,0 +1,6 @@
+---
+deprecated_features:
+  - Support for building ``ansible`` package versions less than ``6.0.0`` is
+    deprecated in antsibull-core
+    (https://github.com/ansible-community/antsibull-core/issues/123,
+    https://github.com/ansible-community/antsibull-core/pull/130).


### PR DESCRIPTION
Relates: https://github.com/ansible-community/antsibull-core/issues/123
