### PR TITLE
Pass CODECOV token to upload action

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -59,3 +59,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           directory: antsibull-core
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This was a breaking change in the codecov/codecov-action@v4 action.