### PR TITLE
[stable-2] Don't fetch release infos when trusting the cache. (#135)

### DIFF
--- a/changelogs/fragments/135-trust-core-cache.yml
+++ b/changelogs/fragments/135-trust-core-cache.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid superfluous network request when trusting the ansible-core download cache (https://github.com/ansible-community/antsibull-core/pull/135)."

--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -143,7 +143,6 @@ class AnsibleCorePyPiClient:
         :returns: The name of the downloaded tarball.
         """
         package_name = get_ansible_core_package_name(ansible_core_version)
-        release_info = await self.get_release_info(package_name)
 
         tar_filename = f"{package_name}-{ansible_core_version}.tar.gz"
         tar_path = os.path.join(download_dir, tar_filename)
@@ -154,6 +153,8 @@ class AnsibleCorePyPiClient:
             if os.path.isfile(cached_path):
                 await copy_file(cached_path, tar_path, check_content=False)
                 return tar_path
+
+        release_info = await self.get_release_info(package_name)
 
         pypi_url = ""
         digests = {}


### PR DESCRIPTION
Manual backport of #135 to stable-2.