### PR TITLE
Fix error message formatting

### DIFF
--- a/src/antsibull_core/ansible_core.py
+++ b/src/antsibull_core/ansible_core.py
@@ -149,7 +149,7 @@ class AnsibleCorePyPiClient:
         else:  # for-else: http://bit.ly/1ElPkyg
             raise UnknownVersion(
                 f"{package_name} {ansible_core_version} does not"
-                " exist on {self.pypi_server_url}"
+                f" exist on {self.pypi_server_url}"
             )
 
         if lib_ctx.ansible_core_cache and "sha256" in digests:


### PR DESCRIPTION
There was an `f` missing for the second line, causing the formatted error message to be something like `antsibull_core.ansible_core.UnknownVersion: ansible-core 2.16.6 does not exist on {self.pypi_server_url}`.