### PR TITLE
Restrict pyre-check version for antsibull 0.61.0 compatibility check; fix pyre-check errors; prepare asyncio.TimeoutError removal

### DIFF
--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -40,12 +40,17 @@ jobs:
 
       # nb: this is the first version of antsibull that declares support
       # for antsibull-core v3.
-      - name: Check out antsibull main
+      - name: Check out antsibull 0.61.0
         uses: actions/checkout@v4
         with:
           repository: ansible-community/antsibull
           ref: 0.61.0
           path: antsibull
+
+      - name: Patch antsibull pyproject.toml
+        run: |
+          sed -e 's/pyre-check/pyre-check <= 0.9.20,/' -i pyproject.toml
+        working-directory: antsibull
 
       - name: Set up Python 3.12
         id: python

--- a/changelogs/fragments/160-asyncio-timeouterror.yml
+++ b/changelogs/fragments/160-asyncio-timeouterror.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "Make sure that the right ``TimeoutError`` is used in the HTTP retry util.
+     ``asyncio.TimeoutError`` is a deprecated alias of ``TimeoutError`` since Python 3.11
+     (https://github.com/ansible-community/antsibull-core/pull/160)."

--- a/src/antsibull_core/schemas/config.py
+++ b/src/antsibull_core/schemas/config.py
@@ -31,21 +31,18 @@ class BaseModel(p.BaseModel):
     model_config = p.ConfigDict(frozen=True, extra="forbid", validate_default=True)
 
 
-# pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogFiltersModel(BaseModel):
     filter: t.Union[str, Callable]
     args: Sequence[t.Any] = []
     kwargs: Mapping[str, t.Any] = {}
 
 
-# pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogEmitterModel(BaseModel):
     output_name: str
     level: str = LEVEL_CHOICES_F
     filters: list[LogFiltersModel] = []
 
 
-# pyre-ignore[13]: BaseModel initializes attributes when data is loaded
 class LogOutputModel(BaseModel):
     output: t.Union[str, Callable]
     args: Sequence[t.Any] = []

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -22,6 +22,10 @@ from ..logging import log
 mlog = log.fields(mod=__name__)
 
 
+# Since Python 3.11 asyncio.TimeoutError is a deprecated alias of TimeoutError
+_AsyncIoTimeoutError = getattr(asyncio, "TimeoutError", TimeoutError)  # pyre-ignore[16]
+
+
 def _format_call(
     command: str, args: tuple[t.Any, ...], kwargs: Mapping[str, t.Any]
 ) -> str:
@@ -68,7 +72,7 @@ class RetryGetManager:
                     return response
                 status = str(status_code)
                 response.close()
-            except asyncio.TimeoutError:
+            except _AsyncIoTimeoutError:
                 flog.trace()
                 status = "timeout"
                 wait_factor = 0.5

--- a/src/antsibull_core/venv.py
+++ b/src/antsibull_core/venv.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-import venv  # pyre-ignore[21]
+import venv
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NoReturn
 


### PR DESCRIPTION
Ref: https://github.com/ansible-community/antsibull/pull/600

Ref: https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.TimeoutError