### PR TITLE
Make sure that app and lib contexts are cleaned up correctly in case of generator exit

### DIFF
--- a/changelogs/fragments/161-context.yml
+++ b/changelogs/fragments/161-context.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Make sure that app and lib contexts are cleaned up correctly in case of generator exit (https://github.com/ansible-community/antsibull-core/pull/161)."

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -356,10 +356,8 @@ def lib_context(
     reset_token = lib_ctx.set(new_context)
     try:
         yield new_context
-    except GeneratorExit:
-        pass
-
-    lib_ctx.reset(reset_token)
+    finally:
+        lib_ctx.reset(reset_token)
 
 
 @t.overload
@@ -383,10 +381,8 @@ def app_context(new_context=None):
     reset_token = app_ctx.set(new_context)
     try:
         yield new_context
-    except GeneratorExit:
-        pass
-
-    app_ctx.reset(reset_token)
+    finally:
+        app_ctx.reset(reset_token)
 
 
 @contextmanager

--- a/src/antsibull_core/app_context.py
+++ b/src/antsibull_core/app_context.py
@@ -354,7 +354,10 @@ def lib_context(
         new_context = _copy_lib_context()
 
     reset_token = lib_ctx.set(new_context)
-    yield new_context
+    try:
+        yield new_context
+    except GeneratorExit:
+        pass
 
     lib_ctx.reset(reset_token)
 
@@ -378,7 +381,10 @@ def app_context(new_context=None):
         new_context = _copy_app_context()
 
     reset_token = app_ctx.set(new_context)
-    yield new_context
+    try:
+        yield new_context
+    except GeneratorExit:
+        pass
 
     app_ctx.reset(reset_token)
 


### PR DESCRIPTION
pylint complained about this (https://pylint.pycqa.org/en/latest/user_guide/messages/warning/contextmanager-generator-missing-cleanup.html), and this is clearly a real bug. So let's fix it :)