### PR TITLE
Fix typing, use ClientTimeout instead of float, bump aiohttp dependency to 3.3.0+

### DIFF
--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -52,6 +52,12 @@ jobs:
           sed -e 's/pyre-check/pyre-check <= 0.9.20,/' -i pyproject.toml
         working-directory: antsibull
 
+      - name: Patch our pyproject.toml
+        # Necessary for pyre...
+        run: |
+          sed -e 's/aiohttp/aiohttp < 3.10.0,/' -i pyproject.toml
+        working-directory: antsibull-core
+
       - name: Set up Python 3.12
         id: python
         uses: actions/setup-python@v5

--- a/changelogs/fragments/163-aiohttp-timeout.yml
+++ b/changelogs/fragments/163-aiohttp-timeout.yml
@@ -1,3 +1,5 @@
 bugfixes:
   - "Adjust the aiohttp retry GET mananger to use ``ClientTimeout`` instead of a ``float``, since that will be removed in aiohttp 4.0.0
      (https://github.com/ansible-community/antsibull-core/pull/163)."
+  - "Bump asyncio requirement to >= 3.3.0 instead of 3.0.0. Version 3.0.0 likely never worked with the retry code that
+     has been in here basically since he beginning (https://github.com/ansible-community/antsibull-core/pull/163)."

--- a/changelogs/fragments/163-aiohttp-timeout.yml
+++ b/changelogs/fragments/163-aiohttp-timeout.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Adjust the aiohttp retry GET mananger to use ``ClientTimeout`` instead of a ``float``, since that will be removed in aiohttp 4.0.0
+     (https://github.com/ansible-community/antsibull-core/pull/163)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "aiofiles",
-    "aiohttp >= 3.0.0",
+    "aiohttp >= 3.3.0",
     "build",
     # major/minor was introduced here
     "packaging >= 20.0",

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -61,7 +61,7 @@ class RetryGetManager:
             flog.debug("Execute {0}", self.call_string)
             wait_factor: float = 5
             try:
-                response = await self.aio_session.get(
+                response = await self.aio_session.get(  # pyre-ignore[16]
                     *self.args, **self.kwargs, timeout=20
                 )
                 status_code = response.status

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -62,7 +62,7 @@ class RetryGetManager:
             wait_factor: float = 5
             try:
                 response = await self.aio_session.get(  # pyre-ignore[16]
-                    *self.args, **self.kwargs, timeout=20
+                    *self.args, **self.kwargs, timeout=aiohttp.ClientTimeout(total=20)
                 )
                 status_code = response.status
                 flog.debug(f"Status code {status_code}")


### PR DESCRIPTION
I'm not sure whether there is an official deprecation, but the conversion code has been removed from `master` (https://github.com/aio-libs/aiohttp/pull/6328) and there's now (since 3.10.0) typing that makes mypy no longer accept floats. The code in 3.10.0 still accepts them though, so this isn't a runtime issue yet.

Also aiohttp 3.3.0+ is required for the timeout parameter that has been used by the GET retry manager since the beginning, so I updated the dependency version range.

Also pyre doesn't think `ClientSession.get` exists anymore with 3.10.0 :roll_eyes: