### PR TITLE
[stable-2] Fix typing, use ClientTimeout instead of float, bump aiohttp dependency to 3.3.0+

### DIFF
--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -46,6 +46,12 @@ jobs:
           ref: 0.52.0
           path: antsibull
 
+      - name: Patch our pyproject.toml
+        # Necessary for pyre...
+        run: |
+          sed -e 's/aiohttp/aiohttp < 3.10.0,/' -i pyproject.toml
+        working-directory: antsibull-core
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/changelogs/fragments/163-aiohttp-timeout.yml
+++ b/changelogs/fragments/163-aiohttp-timeout.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "Adjust the aiohttp retry GET mananger to use ``ClientTimeout`` instead of a ``float``, since that will be removed in aiohttp 4.0.0
+     (https://github.com/ansible-community/antsibull-core/pull/163)."
+  - "Bump asyncio requirement to >= 3.3.0 instead of 3.0.0. Version 3.0.0 likely never worked with the retry code that
+     has been in here basically since he beginning (https://github.com/ansible-community/antsibull-core/pull/163)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "aiofiles",
-    "aiohttp >= 3.0.0",
+    "aiohttp >= 3.3.0",
     "build",
     # major/minor was introduced here
     "packaging >= 20.0",

--- a/src/antsibull_core/utils/http.py
+++ b/src/antsibull_core/utils/http.py
@@ -61,8 +61,8 @@ class RetryGetManager:
             flog.debug("Execute {0}", self.call_string)
             wait_factor: float = 5
             try:
-                response = await self.aio_session.get(
-                    *self.args, **self.kwargs, timeout=20
+                response = await self.aio_session.get(  # pyre-ignore[16]
+                    *self.args, **self.kwargs, timeout=aiohttp.ClientTimeout(total=20)
                 )
                 status_code = response.status
                 flog.debug(f"Status code {status_code}")


### PR DESCRIPTION
Manual backport of #163 to stable-2. (There was a conflict in the change to the workflow, thus no automatic backport.)