### PR TITLE
Allow to track removed collections in collection-meta.yaml

### DIFF
--- a/changelogs/fragments/173-schema-removal.yml
+++ b/changelogs/fragments/173-schema-removal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow information on removed collections in collection metadata schema (https://github.com/ansible-community/antsibull-core/pull/173)."

--- a/src/antsibull_core/collection_meta.py
+++ b/src/antsibull_core/collection_meta.py
@@ -118,14 +118,13 @@ class _Validator:
         # Check order
         sorted_list = sorted(collection)
         raw_list = list(collection)
-        if raw_list != sorted_list:
-            for raw_entry, sorted_entry in zip(raw_list, sorted_list):
-                if raw_entry != sorted_entry:
-                    self.errors.append(
-                        f"{what} must be sorted; "
-                        f"{sorted_entry!r} must come before {raw_entry}"
-                    )
-                    break
+        for raw_entry, sorted_entry in zip(raw_list, sorted_list):
+            if raw_entry != sorted_entry:
+                self.errors.append(
+                    f"{what} must be sorted; "
+                    f"{sorted_entry!r} must come before {raw_entry}"
+                )
+                break
 
     def _validate_collections(self, data: CollectionsMetadata) -> None:
         # Check order

--- a/src/antsibull_core/collection_meta.py
+++ b/src/antsibull_core/collection_meta.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 import os
 import typing as t
+from collections.abc import Collection
 
 import pydantic as p
 from antsibull_fileutils.yaml import load_yaml_file
 
 from .pydantic import forbid_extras, get_formatted_error_messages
 from .schemas.collection_meta import (
+    BaseRemovalInformation,
     CollectionMetadata,
     CollectionsMetadata,
     RemovalInformation,
@@ -45,7 +47,7 @@ class _Validator:
         self.major_release = major_release
 
     def _validate_removal_base(
-        self, collection: str, removal: RemovalInformation, prefix: str
+        self, collection: str, removal: BaseRemovalInformation, prefix: str
     ) -> None:
         if removal.reason == "renamed" and removal.new_name == collection:
             self.errors.append(f"{prefix} new_name: Must not be the collection's name")
@@ -85,9 +87,9 @@ class _Validator:
     def _validate_removal_for_removed(
         self, collection: str, removal: RemovedRemovalInformation, prefix: str
     ) -> None:
-        if removal.major_version != self.major_release:
+        if removal.version.major != self.major_release:
             self.errors.append(
-                f"{prefix} major_version: Removal major version {removal.major_version} must"
+                f"{prefix} version: Major version of removal version {removal.version} must"
                 f" be current major version {self.major_release}"
             )
 
@@ -111,24 +113,23 @@ class _Validator:
         self._validate_removal_for_removed(
             collection, meta.removal, f"{prefix} removal ->"
         )
-        if meta.removed_version.major != self.major_release:
-            self.errors.append(
-                f"{prefix} removed_version: Major version of {meta.removed_version}"
-                f" must be the current major version {self.major_release}"
-            )
 
-    def _validate_collections(self, data: CollectionsMetadata) -> None:
+    def _validate_order(self, collection: Collection, what: str) -> None:
         # Check order
-        sorted_list = sorted(data.collections)
-        raw_list = list(data.collections)
+        sorted_list = sorted(collection)
+        raw_list = list(collection)
         if raw_list != sorted_list:
             for raw_entry, sorted_entry in zip(raw_list, sorted_list):
                 if raw_entry != sorted_entry:
                     self.errors.append(
-                        "The collection list must be sorted; "
+                        f"{what} must be sorted; "
                         f"{sorted_entry!r} must come before {raw_entry}"
                     )
                     break
+
+    def _validate_collections(self, data: CollectionsMetadata) -> None:
+        # Check order
+        self._validate_order(data.collections, "The collection list")
 
         # Validate collection data
         remaining_collections = set(self.all_collections)
@@ -149,16 +150,7 @@ class _Validator:
 
     def _validate_removed_collections(self, data: CollectionsMetadata) -> None:
         # Check order
-        sorted_list = sorted(data.removed_collections)
-        raw_list = list(data.removed_collections)
-        if raw_list != sorted_list:
-            for raw_entry, sorted_entry in zip(raw_list, sorted_list):
-                if raw_entry != sorted_entry:
-                    self.errors.append(
-                        "The removed collection list must be sorted; "
-                        f"{sorted_entry!r} must come before {raw_entry}"
-                    )
-                    break
+        self._validate_order(data.removed_collections, "The removed collection list")
 
         # Validate removed collection data
         for collection, removed_meta in data.removed_collections.items():

--- a/src/antsibull_core/schemas/collection_meta.py
+++ b/src/antsibull_core/schemas/collection_meta.py
@@ -51,7 +51,10 @@ class RemovalInformation(p.BaseModel):
 
     model_config = p.ConfigDict(arbitrary_types_allowed=True)
 
+    # The Ansible major version from which the collection will be removed.
     major_version: t.Union[int, t.Literal["TBD"]]
+
+    # The reason because of which the collection will be removed.
     reason: t.Literal[
         "deprecated",
         "considered-unmaintained",
@@ -60,9 +63,19 @@ class RemovalInformation(p.BaseModel):
         "other",
     ]
     reason_text: t.Optional[str] = None
+
+    # The Ansible version in which the announcement was made. This is needed
+    # for changelog generation.
     announce_version: t.Optional[PydanticPypiVersion] = None
+
+    # In case reason=renamed, the new name of the collection.
     new_name: t.Optional[str] = None
+
+    # The link to the discussion of the removal.
     discussion: t.Optional[p.HttpUrl] = None
+
+    # In case reason=renamed, the major Ansible release in which the collection's
+    # contents have been replaced by deprecated redirects.
     redirect_replacement_major_version: t.Optional[int] = None
 
     @p.model_validator(mode="after")  # pyre-ignore[56]
@@ -125,12 +138,24 @@ class BaseCollectionMetadata(p.BaseModel):
     Stores metadata about one collection.
     """
 
+    # If the collection does not use changelogs/changelog.yaml, it can provide
+    # an URL where the collection's changelog can be found.
     changelog_url: t.Optional[str] = p.Field(alias="changelog-url", default=None)
+
+    # In case the collection is not located in the root of its repository, the
+    # subdirectory in which the collection appears.
     collection_directory: t.Optional[str] = p.Field(
         alias="collection-directory", default=None
     )
+
+    # The collection's repository.
     repository: t.Optional[str] = None
+
+    # A regular expression to match the collection's version from a tag in the repository.
     tag_version_regex: t.Optional[str] = None
+
+    # A list of maintainers. These should be usernames for the repository's
+    # hosting environment.
     maintainers: list[str] = []
 
 
@@ -139,6 +164,8 @@ class CollectionMetadata(BaseCollectionMetadata):
     Stores metadata about one collection.
     """
 
+    # Optional information that the collection will be removed from
+    # a future Ansible release.
     removal: t.Optional[RemovalInformation] = None
 
 
@@ -149,7 +176,11 @@ class RemovedCollectionMetadata(BaseCollectionMetadata):
 
     model_config = p.ConfigDict(arbitrary_types_allowed=True)
 
+    # Information why the collection has been removed
     removal: RemovedRemovalInformation
+
+    # The exact version from which the collection has been removed.
+    # This is needed for changelog generation.
     removed_version: PydanticPypiVersion
 
 
@@ -158,7 +189,10 @@ class CollectionsMetadata(p.BaseModel):
     Stores metadata about a set of collections.
     """
 
+    # Metadata on the collections included in Ansible.
     collections: dict[str, CollectionMetadata]
+
+    # Metadata on the collections removed from this major version of Ansible.
     removed_collections: dict[str, RemovedCollectionMetadata] = {}
 
     @staticmethod

--- a/src/antsibull_core/schemas/collection_meta.py
+++ b/src/antsibull_core/schemas/collection_meta.py
@@ -139,7 +139,7 @@ class BaseCollectionMetadata(p.BaseModel):
     """
 
     # If the collection does not use changelogs/changelog.yaml, it can provide
-    # an URL where the collection's changelog can be found.
+    # a URL where the collection's changelog can be found.
     changelog_url: t.Optional[str] = p.Field(alias="changelog-url", default=None)
 
     # In case the collection is not located in the root of its repository, the

--- a/src/antsibull_core/schemas/collection_meta.py
+++ b/src/antsibull_core/schemas/collection_meta.py
@@ -112,7 +112,15 @@ class RemovalInformation(p.BaseModel):
         return self
 
 
-class CollectionMetadata(p.BaseModel):
+class RemovedRemovalInformation(RemovalInformation):
+    """
+    Stores metadata on when and why a collection was removed.
+    """
+
+    major_version: int
+
+
+class BaseCollectionMetadata(p.BaseModel):
     """
     Stores metadata about one collection.
     """
@@ -124,7 +132,25 @@ class CollectionMetadata(p.BaseModel):
     repository: t.Optional[str] = None
     tag_version_regex: t.Optional[str] = None
     maintainers: list[str] = []
+
+
+class CollectionMetadata(BaseCollectionMetadata):
+    """
+    Stores metadata about one collection.
+    """
+
     removal: t.Optional[RemovalInformation] = None
+
+
+class RemovedCollectionMetadata(BaseCollectionMetadata):
+    """
+    Stores metadata about a removed collection.
+    """
+
+    model_config = p.ConfigDict(arbitrary_types_allowed=True)
+
+    removal: RemovedRemovalInformation
+    removed_version: PydanticPypiVersion
 
 
 class CollectionsMetadata(p.BaseModel):
@@ -133,6 +159,7 @@ class CollectionsMetadata(p.BaseModel):
     """
 
     collections: dict[str, CollectionMetadata]
+    removed_collections: dict[str, RemovedCollectionMetadata] = {}
 
     @staticmethod
     def load_from(deps_dir: StrPath | None) -> CollectionsMetadata:

--- a/src/antsibull_core/schemas/collection_meta.py
+++ b/src/antsibull_core/schemas/collection_meta.py
@@ -154,7 +154,8 @@ class RemovedRemovalInformation(BaseRemovalInformation):
             and self.redirect_replacement_major_version >= self.version.major
         ):
             raise ValueError(
-                "redirect_replacement_major_version must be smaller than major_version"
+                "redirect_replacement_major_version must be smaller than"
+                " version's major version"
             )
         return self
 

--- a/tests/functional/test_collection_meta.py
+++ b/tests/functional/test_collection_meta.py
@@ -137,6 +137,22 @@ collections:
       reason_text: The collection wasn't cow friendly, so the Steering Committee decided to kick it out.
       discussion: https://forum.ansible.com/...
       announce_version: 9.3.0
+removed_collections:
+  bad.baz2:
+    repository: https://github.com/ansible-collections/collection_template
+    removed_version: 10.2.1
+    removal:
+      major_version: 9
+      reason: renamed
+      new_name: bad.bar2
+      announce_version: 9.3.0
+      redirect_replacement_major_version: 7
+  bad.baz1:
+    removed_version: 9.1.0
+    removal:
+      major_version: 8
+      reason: deprecated
+      announce_version: 7.1.0
 """,
         [
             "foo.bar",
@@ -153,6 +169,7 @@ collections:
         ],
         [
             "The collection list must be sorted; 'baz.bam' must come before foo.bar",
+            "The removed collection list must be sorted; 'bad.baz1' must come before bad.baz2",
             "collections -> bad.bar1 -> removal -> announce_version: Major version of 10.1.0 must not be larger than the current major version 9",
             "collections -> bad.bar1 -> removal -> major_version: Removal major version 7 must be larger than current major version 9",
             "collections -> bad.bar1: Collection not in ansible.in",
@@ -162,6 +179,10 @@ collections:
             "collections -> baz.bam: Collection not in ansible.in",
             "collections -> foo.bar -> repository: Required field not provided",
             "collections: No metadata present for not.there",
+            "removed_collections -> bad.baz1 -> removal -> major_version: Removal major version 8 must be current major version 9",
+            "removed_collections -> bad.baz1 -> repository: Required field not provided",
+            "removed_collections -> bad.baz2 -> removal -> announce_version: Major version of 9.3.0 must be less than the current major version 9",
+            "removed_collections -> bad.baz2 -> removed_version: Major version of 10.2.1 must be the current major version 9",
         ],
     ),
     (
@@ -271,6 +292,18 @@ collections:
     removal:
       major_version: 11
       reason: foo
+removed_collections:
+  bad.foo1:
+    repository: https://github.com/ansible-collections/collection_template
+    removed_version: 1.0.0
+    removal:
+      major_version: TBD
+      reason: deprecated
+  bad.foo2:
+    repository: https://github.com/ansible-collections/collection_template
+    removal:
+      major_version: 10
+      reason: deprecated
 extra_stuff: baz
 """,
         [],
@@ -292,6 +325,8 @@ extra_stuff: baz
             "collections -> bad.foo8 -> removal: Value error, new_name must not be provided if reason is not 'renamed'",
             "collections -> bad.foo9 -> removal: Value error, redirect_replacement_major_version must not be provided if reason is not 'renamed'",
             "extra_stuff: Extra inputs are not permitted",
+            "removed_collections -> bad.foo1 -> removal -> major_version: Input should be a valid integer, unable to parse string as an integer",
+            "removed_collections -> bad.foo2 -> removed_version: Field required",
         ],
     ),
 ]

--- a/tests/functional/test_collection_meta.py
+++ b/tests/functional/test_collection_meta.py
@@ -306,6 +306,13 @@ removed_collections:
     repository: https://github.com/ansible-collections/collection_template
     removal:
       reason: deprecated
+  bad.foo3:
+    repository: https://github.com/ansible-collections/collection_template
+    removal:
+      version: 9.0.0
+      reason: renamed
+      new_name: bad.foo3_new
+      redirect_replacement_major_version: 12
 extra_stuff: baz
 """,
         [],
@@ -329,6 +336,7 @@ extra_stuff: baz
             "extra_stuff: Extra inputs are not permitted",
             "removed_collections -> bad.foo1 -> removal -> version: Value error, Invalid version: 'TBD'",
             "removed_collections -> bad.foo2 -> removal -> version: Field required",
+            "removed_collections -> bad.foo3 -> removal: Value error, redirect_replacement_major_version must be smaller than version's major version",
         ],
     ),
 ]

--- a/tests/functional/test_collection_meta.py
+++ b/tests/functional/test_collection_meta.py
@@ -140,17 +140,21 @@ collections:
 removed_collections:
   bad.baz2:
     repository: https://github.com/ansible-collections/collection_template
-    removed_version: 10.2.1
     removal:
-      major_version: 9
+      version: 10.2.1
       reason: renamed
       new_name: bad.bar2
       announce_version: 9.3.0
       redirect_replacement_major_version: 7
   bad.baz1:
-    removed_version: 9.1.0
     removal:
-      major_version: 8
+      version: 9.1.0
+      reason: deprecated
+      announce_version: 7.1.0
+  foo.bar:
+    repository: https://github.com/ansible-collections/collection_template
+    removal:
+      version: 9.0.0
       reason: deprecated
       announce_version: 7.1.0
 """,
@@ -179,10 +183,10 @@ removed_collections:
             "collections -> baz.bam: Collection not in ansible.in",
             "collections -> foo.bar -> repository: Required field not provided",
             "collections: No metadata present for not.there",
-            "removed_collections -> bad.baz1 -> removal -> major_version: Removal major version 8 must be current major version 9",
             "removed_collections -> bad.baz1 -> repository: Required field not provided",
             "removed_collections -> bad.baz2 -> removal -> announce_version: Major version of 9.3.0 must be less than the current major version 9",
-            "removed_collections -> bad.baz2 -> removed_version: Major version of 10.2.1 must be the current major version 9",
+            "removed_collections -> bad.baz2 -> removal -> version: Major version of removal version 10.2.1 must be current major version 9",
+            "removed_collections -> foo.bar: Collection in ansible.in",
         ],
     ),
     (
@@ -295,14 +299,12 @@ collections:
 removed_collections:
   bad.foo1:
     repository: https://github.com/ansible-collections/collection_template
-    removed_version: 1.0.0
     removal:
-      major_version: TBD
+      version: TBD
       reason: deprecated
   bad.foo2:
     repository: https://github.com/ansible-collections/collection_template
     removal:
-      major_version: 10
       reason: deprecated
 extra_stuff: baz
 """,
@@ -325,8 +327,8 @@ extra_stuff: baz
             "collections -> bad.foo8 -> removal: Value error, new_name must not be provided if reason is not 'renamed'",
             "collections -> bad.foo9 -> removal: Value error, redirect_replacement_major_version must not be provided if reason is not 'renamed'",
             "extra_stuff: Extra inputs are not permitted",
-            "removed_collections -> bad.foo1 -> removal -> major_version: Input should be a valid integer, unable to parse string as an integer",
-            "removed_collections -> bad.foo2 -> removed_version: Field required",
+            "removed_collections -> bad.foo1 -> removal -> version: Value error, Invalid version: 'TBD'",
+            "removed_collections -> bad.foo2 -> removal -> version: Field required",
         ],
     ),
 ]


### PR DESCRIPTION
This allows to create all changelog fragments related to deprecated and removed collections automatically.