### PR TITLE
Allow removed collection information from previous major releases

### DIFF
--- a/changelogs/fragments/174-removed-in-previous.yml
+++ b/changelogs/fragments/174-removed-in-previous.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow information on removed collections from previous major releases in collection metadata schema (https://github.com/ansible-community/antsibull-core/pull/174).

--- a/src/antsibull_core/collection_meta.py
+++ b/src/antsibull_core/collection_meta.py
@@ -87,10 +87,10 @@ class _Validator:
     def _validate_removal_for_removed(
         self, collection: str, removal: RemovedRemovalInformation, prefix: str
     ) -> None:
-        if removal.version.major != self.major_release:
+        if removal.version.major > self.major_release:
             self.errors.append(
                 f"{prefix} version: Major version of removal version {removal.version} must"
-                f" be current major version {self.major_release}"
+                f" not be larger than current major version {self.major_release}"
             )
 
         if (

--- a/tests/functional/test_collection_meta.py
+++ b/tests/functional/test_collection_meta.py
@@ -185,7 +185,7 @@ removed_collections:
             "collections: No metadata present for not.there",
             "removed_collections -> bad.baz1 -> repository: Required field not provided",
             "removed_collections -> bad.baz2 -> removal -> announce_version: Major version of 9.3.0 must be less than the current major version 9",
-            "removed_collections -> bad.baz2 -> removal -> version: Major version of removal version 10.2.1 must be current major version 9",
+            "removed_collections -> bad.baz2 -> removal -> version: Major version of removal version 10.2.1 must not be larger than current major version 9",
             "removed_collections -> foo.bar: Collection in ansible.in",
         ],
     ),


### PR DESCRIPTION
This allows to improve https://github.com/ansible-community/antsibull-docs/pull/341 to also create stubs for collections removed in older major Ansible releases.