### PR TITLE
Add Python 3.13 to CI and supported Python versions

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -57,11 +57,11 @@ jobs:
           sed -i noxfile.py -e 's/args = ("antsibull-core", "antsibull-docs-parser")/args = ("antsibull-core", "antsibull-docs-parser", "antsibull-fileutils")/g'
         working-directory: antsibull-docs
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         id: python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/antsibull.yml
+++ b/.github/workflows/antsibull.yml
@@ -69,11 +69,11 @@ jobs:
           sed -e 's/aiohttp/aiohttp < 3.10.0,/' -i pyproject.toml
         working-directory: antsibull-core
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         id: python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -33,12 +33,12 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.9, 3.10, 3.11, 3.12"
+            python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
             codecov: true
             packages: ""
 
           - session: lint
-            python-versions: "3.12"
+            python-versions: "3.13"
             codecov: false
             packages: ""
     name: "Run nox ${{ matrix.session }} session"

--- a/changelogs/fragments/python-3.13.yml
+++ b/changelogs/fragments/python-3.13.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Declare support for Python 3.13 (https://github.com/ansible-community/antsibull-core/pull/176).

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def other_antsibull(
     return to_install
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(
         session,
@@ -77,7 +77,7 @@ def test(session: nox.Session):
     )
     covfile = Path(session.create_tmp(), ".coverage")
     more_args = []
-    if session.python == "3.12":
+    if session.python in {"3.12", "3.13"}:
         more_args.append("--error-for-skips")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Since Python 3.13.0 has been released, let's use it in CI and officially support it.