### PR TITLE
Restrict pyre version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ test = [
 typing = [
     "mypy",
     # https://github.com/facebook/pyre-check/issues/398
-    "pyre-check >= 0.9.17",
+    "pyre-check >= 0.9.17, < 0.9.23",
     "types-aiofiles",
     "typing-extensions",
 ]


### PR DESCRIPTION
We want to get rid of pyre anyway, so let's pin the upper version. Right now (with the latest version) there are some pyre errors that seem to be hard to fix.