### PR TITLE
Sign release tags and release commits

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -268,6 +268,7 @@ def bump(session: nox.Session):
         "git",
         "tag",
         "-a",
+        "-s",
         "-m",
         f"antsibull-core {version}",
         "--edit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -248,7 +248,9 @@ def bump(session: nox.Session):
             str(fragment_file),
             external=True,
         )
-        session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
+        session.run(
+            "git", "commit", "-m", f"Prepare {version}.", "--gpg-sign", external=True
+        )
     session.run("antsibull-changelog", "release")
     session.run(
         "git",
@@ -263,7 +265,9 @@ def bump(session: nox.Session):
         external=True,
     )
     install(session, ".")  # Smoke test
-    session.run("git", "commit", "-m", f"Release {version}.", external=True)
+    session.run(
+        "git", "commit", "-m", f"Release {version}.", "--gpg-sign", external=True
+    )
     session.run(
         "git",
         "tag",
@@ -288,4 +292,6 @@ def publish(session: nox.Session):
     version = session.run("hatch", "version", silent=True).strip()
     session.run("hatch", "version", "post")
     session.run("git", "add", "src/antsibull_core/__init__.py", external=True)
-    session.run("git", "commit", "-m", "Post-release version bump.", external=True)
+    session.run(
+        "git", "commit", "-m", "Post-release version bump.", "--gpg-sign", external=True
+    )


### PR DESCRIPTION
Make sure that the preparation, release, and post-release commits are signed. When tagging the release commit, also sign it.